### PR TITLE
feat(fetchers): Data Fetchers for Binance and Yahoo Finance

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "maxtrade",
+      "dependencies": {
+        "hono": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+
+    "@types/node": ["@types/node@25.0.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw=="],
+
+    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+
+    "hono": ["hono@4.11.4", "", {}, "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+  }
+}

--- a/src/fetchers/base.ts
+++ b/src/fetchers/base.ts
@@ -1,0 +1,163 @@
+/**
+ * Base Fetcher Implementation
+ * Template Method pattern from QuantMuse - hooks for subclass customization
+ */
+
+import type {
+  Fetcher,
+  FetchResult,
+  OHLCV,
+  Quote,
+  AssetInfo,
+  Interval,
+  PriceCallback,
+  Subscription,
+  OrderBook,
+} from './types';
+import { MemoryCache, cacheKey, globalCache } from './cache';
+
+export interface BaseFetcherOptions {
+  cache?: MemoryCache;
+  cacheTTL?: {
+    quote: number;
+    historical: number;
+    assetInfo: number;
+    orderBook: number;
+  };
+}
+
+const DEFAULT_TTL = {
+  quote: 5_000, // 5 seconds for real-time quotes
+  historical: 300_000, // 5 minutes for historical data
+  assetInfo: 3600_000, // 1 hour for asset info
+  orderBook: 1_000, // 1 second for order book
+};
+
+/**
+ * Abstract Base Fetcher
+ * Provides caching, error handling, and common utilities
+ */
+export abstract class BaseFetcher implements Fetcher {
+  abstract readonly name: string;
+  abstract readonly supportedTypes: AssetInfo['type'][];
+
+  protected cache: MemoryCache;
+  protected cacheTTL: typeof DEFAULT_TTL;
+
+  constructor(options: BaseFetcherOptions = {}) {
+    this.cache = options.cache ?? globalCache;
+    this.cacheTTL = { ...DEFAULT_TTL, ...options.cacheTTL };
+  }
+
+  /** Must be implemented by subclasses */
+  protected abstract fetchHistoricalData(
+    symbol: string,
+    interval: Interval,
+    options?: { startTime?: number; endTime?: number; limit?: number }
+  ): Promise<OHLCV[]>;
+
+  protected abstract fetchCurrentPrice(symbol: string): Promise<Quote>;
+
+  protected abstract fetchAssetInfo(symbol: string): Promise<AssetInfo>;
+
+  /** Get historical data with caching */
+  async getHistoricalData(
+    symbol: string,
+    interval: Interval,
+    options?: { startTime?: number; endTime?: number; limit?: number }
+  ): Promise<FetchResult<OHLCV[]>> {
+    const key = cacheKey(
+      this.name,
+      'historical',
+      symbol,
+      interval,
+      options?.startTime,
+      options?.endTime,
+      options?.limit
+    );
+
+    const cached = this.cache.get<OHLCV[]>(key);
+    if (cached) {
+      return this.wrapResult(cached, true, 0);
+    }
+
+    const start = Date.now();
+    const data = await this.fetchHistoricalData(symbol, interval, options);
+    const latency = Date.now() - start;
+
+    this.cache.set(key, data, this.cacheTTL.historical);
+    return this.wrapResult(data, false, latency);
+  }
+
+  /** Get current price with caching */
+  async getCurrentPrice(symbol: string): Promise<FetchResult<Quote>> {
+    const key = cacheKey(this.name, 'quote', symbol);
+
+    const cached = this.cache.get<Quote>(key);
+    if (cached) {
+      return this.wrapResult(cached, true, 0);
+    }
+
+    const start = Date.now();
+    const data = await this.fetchCurrentPrice(symbol);
+    const latency = Date.now() - start;
+
+    this.cache.set(key, data, this.cacheTTL.quote);
+    return this.wrapResult(data, false, latency);
+  }
+
+  /** Get asset info with caching */
+  async getAssetInfo(symbol: string): Promise<FetchResult<AssetInfo>> {
+    const key = cacheKey(this.name, 'info', symbol);
+
+    const cached = this.cache.get<AssetInfo>(key);
+    if (cached) {
+      return this.wrapResult(cached, true, 0);
+    }
+
+    const start = Date.now();
+    const data = await this.fetchAssetInfo(symbol);
+    const latency = Date.now() - start;
+
+    this.cache.set(key, data, this.cacheTTL.assetInfo);
+    return this.wrapResult(data, false, latency);
+  }
+
+  /** Optional: Subscribe to real-time updates */
+  subscribe?(symbol: string, callback: PriceCallback): Subscription;
+
+  /** Optional: Get order book */
+  getOrderBook?(symbol: string, limit?: number): Promise<FetchResult<OrderBook>>;
+
+  /** Health check - default implementation */
+  async healthCheck(): Promise<boolean> {
+    try {
+      // Try to fetch a common asset
+      await this.getCurrentPrice(this.getHealthCheckSymbol());
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Symbol to use for health checks - override in subclass */
+  protected getHealthCheckSymbol(): string {
+    return 'BTCUSDT';
+  }
+
+  /** Wrap data in FetchResult */
+  protected wrapResult<T>(data: T, cached: boolean, latencyMs: number): FetchResult<T> {
+    return {
+      data,
+      source: this.name,
+      cached,
+      timestamp: Date.now(),
+      latencyMs,
+    };
+  }
+
+  /** Normalize symbol for this exchange */
+  protected normalizeSymbol(symbol: string): string {
+    return symbol.toUpperCase().replace(/[^A-Z0-9]/g, '');
+  }
+}

--- a/src/fetchers/binance.ts
+++ b/src/fetchers/binance.ts
@@ -1,0 +1,264 @@
+/**
+ * Binance Data Fetcher
+ * Crypto market data via Binance public API
+ */
+
+import { BaseFetcher, type BaseFetcherOptions } from './base';
+import type {
+  OHLCV,
+  Quote,
+  AssetInfo,
+  Interval,
+  PriceCallback,
+  Subscription,
+  OrderBook,
+  FetchResult,
+} from './types';
+import { cacheKey } from './cache';
+
+const BINANCE_API = 'https://api.binance.com/api/v3';
+const BINANCE_WS = 'wss://stream.binance.com:9443/ws';
+
+/** Binance interval mapping */
+const INTERVAL_MAP: Record<Interval, string> = {
+  '1m': '1m',
+  '5m': '5m',
+  '15m': '15m',
+  '1h': '1h',
+  '4h': '4h',
+  '1d': '1d',
+  '1w': '1w',
+  '1M': '1M',
+};
+
+export interface BinanceFetcherOptions extends BaseFetcherOptions {
+  baseUrl?: string;
+  wsUrl?: string;
+}
+
+export class BinanceFetcher extends BaseFetcher {
+  readonly name = 'binance';
+  readonly supportedTypes: AssetInfo['type'][] = ['crypto'];
+
+  private baseUrl: string;
+  private wsUrl: string;
+  private subscriptions: Map<string, WebSocket> = new Map();
+
+  constructor(options: BinanceFetcherOptions = {}) {
+    super(options);
+    this.baseUrl = options.baseUrl ?? BINANCE_API;
+    this.wsUrl = options.wsUrl ?? BINANCE_WS;
+  }
+
+  protected async fetchHistoricalData(
+    symbol: string,
+    interval: Interval,
+    options?: { startTime?: number; endTime?: number; limit?: number }
+  ): Promise<OHLCV[]> {
+    const params = new URLSearchParams({
+      symbol: this.normalizeSymbol(symbol),
+      interval: INTERVAL_MAP[interval],
+      limit: String(options?.limit ?? 500),
+    });
+
+    if (options?.startTime) params.set('startTime', String(options.startTime));
+    if (options?.endTime) params.set('endTime', String(options.endTime));
+
+    const response = await fetch(`${this.baseUrl}/klines?${params}`);
+
+    if (!response.ok) {
+      throw new Error(`Binance API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as (string | number)[][];
+
+    return data.map((candle) => ({
+      timestamp: candle[0] as number,
+      open: parseFloat(candle[1] as string),
+      high: parseFloat(candle[2] as string),
+      low: parseFloat(candle[3] as string),
+      close: parseFloat(candle[4] as string),
+      volume: parseFloat(candle[5] as string),
+    }));
+  }
+
+  protected async fetchCurrentPrice(symbol: string): Promise<Quote> {
+    const normalizedSymbol = this.normalizeSymbol(symbol);
+
+    // Fetch ticker and book ticker in parallel
+    const [tickerRes, bookRes] = await Promise.all([
+      fetch(`${this.baseUrl}/ticker/price?symbol=${normalizedSymbol}`),
+      fetch(`${this.baseUrl}/ticker/bookTicker?symbol=${normalizedSymbol}`),
+    ]);
+
+    if (!tickerRes.ok || !bookRes.ok) {
+      throw new Error(`Binance API error fetching quote for ${symbol}`);
+    }
+
+    const ticker = (await tickerRes.json()) as { symbol: string; price: string };
+    const book = (await bookRes.json()) as {
+      bidPrice: string;
+      bidQty: string;
+      askPrice: string;
+      askQty: string;
+    };
+
+    return {
+      symbol: normalizedSymbol,
+      price: parseFloat(ticker.price),
+      bid: parseFloat(book.bidPrice),
+      ask: parseFloat(book.askPrice),
+      volume: 0, // Need 24hr ticker for volume
+      timestamp: Date.now(),
+    };
+  }
+
+  protected async fetchAssetInfo(symbol: string): Promise<AssetInfo> {
+    const normalizedSymbol = this.normalizeSymbol(symbol);
+
+    const response = await fetch(`${this.baseUrl}/exchangeInfo?symbol=${normalizedSymbol}`);
+
+    if (!response.ok) {
+      throw new Error(`Binance API error: ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      symbols: Array<{
+        symbol: string;
+        baseAsset: string;
+        quoteAsset: string;
+        status: string;
+      }>;
+    };
+
+    const info = data.symbols[0];
+    if (!info) {
+      throw new Error(`Symbol ${symbol} not found on Binance`);
+    }
+
+    return {
+      symbol: info.symbol,
+      name: `${info.baseAsset}/${info.quoteAsset}`,
+      exchange: 'binance',
+      type: 'crypto',
+      currency: info.quoteAsset,
+      metadata: {
+        baseAsset: info.baseAsset,
+        quoteAsset: info.quoteAsset,
+        status: info.status,
+      },
+    };
+  }
+
+  /** Subscribe to real-time price updates via WebSocket */
+  subscribe(symbol: string, callback: PriceCallback): Subscription {
+    const normalizedSymbol = this.normalizeSymbol(symbol).toLowerCase();
+    const streamName = `${normalizedSymbol}@ticker`;
+
+    // Check if already subscribed
+    if (this.subscriptions.has(streamName)) {
+      throw new Error(`Already subscribed to ${symbol}`);
+    }
+
+    const ws = new WebSocket(`${this.wsUrl}/${streamName}`);
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data as string) as {
+          s: string; // symbol
+          c: string; // close price
+          b: string; // bid
+          a: string; // ask
+          v: string; // volume
+          E: number; // event time
+        };
+
+        callback({
+          symbol: data.s,
+          price: parseFloat(data.c),
+          bid: parseFloat(data.b),
+          ask: parseFloat(data.a),
+          volume: parseFloat(data.v),
+          timestamp: data.E,
+        });
+      } catch {
+        // Ignore parse errors
+      }
+    };
+
+    ws.onerror = () => {
+      this.subscriptions.delete(streamName);
+    };
+
+    ws.onclose = () => {
+      this.subscriptions.delete(streamName);
+    };
+
+    this.subscriptions.set(streamName, ws);
+
+    return {
+      symbol,
+      unsubscribe: () => {
+        ws.close();
+        this.subscriptions.delete(streamName);
+      },
+    };
+  }
+
+  /** Get order book depth */
+  async getOrderBook(symbol: string, limit = 20): Promise<FetchResult<OrderBook>> {
+    const key = cacheKey(this.name, 'orderbook', symbol, limit);
+
+    const cached = this.cache.get<OrderBook>(key);
+    if (cached) {
+      return this.wrapResult(cached, true, 0);
+    }
+
+    const start = Date.now();
+    const normalizedSymbol = this.normalizeSymbol(symbol);
+
+    const response = await fetch(
+      `${this.baseUrl}/depth?symbol=${normalizedSymbol}&limit=${limit}`
+    );
+
+    if (!response.ok) {
+      throw new Error(`Binance API error: ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      lastUpdateId: number;
+      bids: [string, string][];
+      asks: [string, string][];
+    };
+
+    const orderBook: OrderBook = {
+      symbol: normalizedSymbol,
+      timestamp: Date.now(),
+      bids: data.bids.map(([price, qty]) => ({
+        price: parseFloat(price),
+        quantity: parseFloat(qty),
+      })),
+      asks: data.asks.map(([price, qty]) => ({
+        price: parseFloat(price),
+        quantity: parseFloat(qty),
+      })),
+    };
+
+    const latency = Date.now() - start;
+    this.cache.set(key, orderBook, this.cacheTTL.orderBook);
+
+    return this.wrapResult(orderBook, false, latency);
+  }
+
+  protected getHealthCheckSymbol(): string {
+    return 'BTCUSDT';
+  }
+
+  /** Close all WebSocket connections */
+  closeAll(): void {
+    for (const ws of this.subscriptions.values()) {
+      ws.close();
+    }
+    this.subscriptions.clear();
+  }
+}

--- a/src/fetchers/cache.ts
+++ b/src/fetchers/cache.ts
@@ -1,0 +1,142 @@
+/**
+ * In-Memory Cache with TTL
+ * Graceful degradation pattern - in-memory first, Redis optional
+ */
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+  createdAt: number;
+}
+
+export interface CacheOptions {
+  defaultTTL: number; // milliseconds
+  maxSize: number;
+  onEvict?: (key: string) => void;
+}
+
+export class MemoryCache {
+  private cache: Map<string, CacheEntry<unknown>> = new Map();
+  private options: CacheOptions;
+  private hits = 0;
+  private misses = 0;
+
+  constructor(options: Partial<CacheOptions> = {}) {
+    this.options = {
+      defaultTTL: 60_000, // 1 minute default
+      maxSize: 10_000,
+      ...options,
+    };
+  }
+
+  /** Get value from cache */
+  get<T>(key: string): T | undefined {
+    const entry = this.cache.get(key) as CacheEntry<T> | undefined;
+
+    if (!entry) {
+      this.misses++;
+      return undefined;
+    }
+
+    // Check expiration
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      this.misses++;
+      return undefined;
+    }
+
+    this.hits++;
+    return entry.data;
+  }
+
+  /** Set value in cache */
+  set<T>(key: string, data: T, ttl?: number): void {
+    // Evict if at capacity
+    if (this.cache.size >= this.options.maxSize) {
+      this.evictOldest();
+    }
+
+    const now = Date.now();
+    this.cache.set(key, {
+      data,
+      createdAt: now,
+      expiresAt: now + (ttl ?? this.options.defaultTTL),
+    });
+  }
+
+  /** Delete from cache */
+  delete(key: string): boolean {
+    return this.cache.delete(key);
+  }
+
+  /** Clear all cache */
+  clear(): void {
+    this.cache.clear();
+    this.hits = 0;
+    this.misses = 0;
+  }
+
+  /** Check if key exists and is not expired */
+  has(key: string): boolean {
+    const entry = this.cache.get(key);
+    if (!entry) return false;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  /** Get cache statistics */
+  getStats(): { hits: number; misses: number; hitRate: number; size: number } {
+    const total = this.hits + this.misses;
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      hitRate: total > 0 ? this.hits / total : 0,
+      size: this.cache.size,
+    };
+  }
+
+  /** Evict oldest entries */
+  private evictOldest(): void {
+    // Evict 10% of oldest entries
+    const toEvict = Math.max(1, Math.floor(this.cache.size * 0.1));
+    const keys = Array.from(this.cache.keys()).slice(0, toEvict);
+
+    for (const key of keys) {
+      this.cache.delete(key);
+      this.options.onEvict?.(key);
+    }
+  }
+
+  /** Clean up expired entries */
+  cleanup(): number {
+    const now = Date.now();
+    let cleaned = 0;
+
+    for (const [key, entry] of this.cache.entries()) {
+      if (now > entry.expiresAt) {
+        this.cache.delete(key);
+        cleaned++;
+      }
+    }
+
+    return cleaned;
+  }
+}
+
+/** Generate cache key for fetcher operations */
+export function cacheKey(
+  fetcher: string,
+  operation: string,
+  ...args: (string | number | undefined)[]
+): string {
+  return `${fetcher}:${operation}:${args.filter(Boolean).join(':')}`;
+}
+
+/** Shared cache instance */
+export const globalCache = new MemoryCache({
+  defaultTTL: 60_000, // 1 minute
+  maxSize: 50_000,
+});

--- a/src/fetchers/index.ts
+++ b/src/fetchers/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Data Fetchers Module
+ * Market data ingestion for MaxTrade
+ */
+
+// Types
+export type {
+  OHLCV,
+  OrderBook,
+  OrderBookEntry,
+  Quote,
+  AssetInfo,
+  Interval,
+  FetchResult,
+  PriceCallback,
+  Subscription,
+  Fetcher,
+  FetcherRegistry,
+} from './types';
+
+// Cache
+export { MemoryCache, cacheKey, globalCache } from './cache';
+export type { CacheOptions } from './cache';
+
+// Base
+export { BaseFetcher } from './base';
+export type { BaseFetcherOptions } from './base';
+
+// Implementations
+export { BinanceFetcher } from './binance';
+export type { BinanceFetcherOptions } from './binance';
+
+export { YahooFetcher } from './yahoo';
+export type { YahooFetcherOptions } from './yahoo';
+
+// Registry
+export { fetcherRegistry, initializeDefaultFetchers } from './registry';

--- a/src/fetchers/registry.ts
+++ b/src/fetchers/registry.ts
@@ -1,0 +1,76 @@
+/**
+ * Fetcher Registry
+ * Service Locator pattern from QuantMuse
+ * Manages multiple data sources with type-based lookup
+ */
+
+import type { Fetcher, FetcherRegistry, AssetInfo } from './types';
+
+class FetcherRegistryImpl implements FetcherRegistry {
+  private fetchers: Map<string, Fetcher> = new Map();
+
+  /** Register a fetcher */
+  register(fetcher: Fetcher): void {
+    if (this.fetchers.has(fetcher.name)) {
+      console.warn(`Fetcher ${fetcher.name} already registered, replacing`);
+    }
+    this.fetchers.set(fetcher.name, fetcher);
+  }
+
+  /** Get fetcher by name */
+  get(name: string): Fetcher | undefined {
+    return this.fetchers.get(name);
+  }
+
+  /** Get all fetchers supporting a specific asset type */
+  getForType(type: AssetInfo['type']): Fetcher[] {
+    return Array.from(this.fetchers.values()).filter((f) =>
+      f.supportedTypes.includes(type)
+    );
+  }
+
+  /** List all registered fetcher names */
+  list(): string[] {
+    return Array.from(this.fetchers.keys());
+  }
+
+  /** Unregister a fetcher */
+  unregister(name: string): boolean {
+    return this.fetchers.delete(name);
+  }
+
+  /** Clear all fetchers */
+  clear(): void {
+    this.fetchers.clear();
+  }
+
+  /** Check health of all fetchers */
+  async healthCheckAll(): Promise<Map<string, boolean>> {
+    const results = new Map<string, boolean>();
+
+    await Promise.all(
+      Array.from(this.fetchers.entries()).map(async ([name, fetcher]) => {
+        try {
+          const healthy = await fetcher.healthCheck();
+          results.set(name, healthy);
+        } catch {
+          results.set(name, false);
+        }
+      })
+    );
+
+    return results;
+  }
+}
+
+/** Global fetcher registry singleton */
+export const fetcherRegistry = new FetcherRegistryImpl();
+
+/** Initialize default fetchers */
+export async function initializeDefaultFetchers(): Promise<void> {
+  const { BinanceFetcher } = await import('./binance');
+  const { YahooFetcher } = await import('./yahoo');
+
+  fetcherRegistry.register(new BinanceFetcher());
+  fetcherRegistry.register(new YahooFetcher());
+}

--- a/src/fetchers/types.ts
+++ b/src/fetchers/types.ts
@@ -1,0 +1,115 @@
+/**
+ * Data Fetcher Types
+ * Based on QuantMuse patterns - dataclass style for immutable data
+ */
+
+/** OHLCV candle data */
+export interface OHLCV {
+  timestamp: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+/** Order book entry */
+export interface OrderBookEntry {
+  price: number;
+  quantity: number;
+}
+
+/** Order book depth */
+export interface OrderBook {
+  symbol: string;
+  timestamp: number;
+  bids: OrderBookEntry[];
+  asks: OrderBookEntry[];
+}
+
+/** Real-time quote */
+export interface Quote {
+  symbol: string;
+  price: number;
+  bid: number;
+  ask: number;
+  volume: number;
+  timestamp: number;
+}
+
+/** Company/Asset info */
+export interface AssetInfo {
+  symbol: string;
+  name: string;
+  exchange: string;
+  type: 'stock' | 'crypto' | 'etf' | 'forex';
+  currency: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** Time intervals for historical data */
+export type Interval = '1m' | '5m' | '15m' | '1h' | '4h' | '1d' | '1w' | '1M';
+
+/** Fetcher result wrapper */
+export interface FetchResult<T> {
+  data: T;
+  source: string;
+  cached: boolean;
+  timestamp: number;
+  latencyMs: number;
+}
+
+/** Price callback for subscriptions */
+export type PriceCallback = (quote: Quote) => void;
+
+/** Subscription handle */
+export interface Subscription {
+  symbol: string;
+  unsubscribe: () => void;
+}
+
+/**
+ * Base Fetcher Interface
+ * ABC-style pattern from QuantMuse
+ */
+export interface Fetcher {
+  readonly name: string;
+  readonly supportedTypes: AssetInfo['type'][];
+
+  /** Get historical OHLCV data */
+  getHistoricalData(
+    symbol: string,
+    interval: Interval,
+    options?: {
+      startTime?: number;
+      endTime?: number;
+      limit?: number;
+    }
+  ): Promise<FetchResult<OHLCV[]>>;
+
+  /** Get current price/quote */
+  getCurrentPrice(symbol: string): Promise<FetchResult<Quote>>;
+
+  /** Get asset information */
+  getAssetInfo(symbol: string): Promise<FetchResult<AssetInfo>>;
+
+  /** Subscribe to real-time updates (optional) */
+  subscribe?(symbol: string, callback: PriceCallback): Subscription;
+
+  /** Get order book depth (optional) */
+  getOrderBook?(symbol: string, limit?: number): Promise<FetchResult<OrderBook>>;
+
+  /** Check if fetcher is healthy */
+  healthCheck(): Promise<boolean>;
+}
+
+/**
+ * Fetcher Registry for managing multiple data sources
+ * Service Locator pattern from QuantMuse
+ */
+export interface FetcherRegistry {
+  register(fetcher: Fetcher): void;
+  get(name: string): Fetcher | undefined;
+  getForType(type: AssetInfo['type']): Fetcher[];
+  list(): string[];
+}

--- a/src/fetchers/yahoo.ts
+++ b/src/fetchers/yahoo.ts
@@ -1,0 +1,268 @@
+/**
+ * Yahoo Finance Data Fetcher
+ * Stock market data via Yahoo Finance API
+ */
+
+import { BaseFetcher, type BaseFetcherOptions } from './base';
+import type { OHLCV, Quote, AssetInfo, Interval } from './types';
+
+const YAHOO_API = 'https://query1.finance.yahoo.com/v8/finance';
+
+/** Yahoo interval mapping */
+const INTERVAL_MAP: Record<Interval, string> = {
+  '1m': '1m',
+  '5m': '5m',
+  '15m': '15m',
+  '1h': '1h',
+  '4h': '1h', // Yahoo doesn't have 4h, use 1h
+  '1d': '1d',
+  '1w': '1wk',
+  '1M': '1mo',
+};
+
+/** Yahoo range based on interval */
+const RANGE_MAP: Record<Interval, string> = {
+  '1m': '7d',
+  '5m': '60d',
+  '15m': '60d',
+  '1h': '730d',
+  '4h': '730d',
+  '1d': '10y',
+  '1w': '10y',
+  '1M': '10y',
+};
+
+export interface YahooFetcherOptions extends BaseFetcherOptions {
+  baseUrl?: string;
+}
+
+export class YahooFetcher extends BaseFetcher {
+  readonly name = 'yahoo';
+  readonly supportedTypes: AssetInfo['type'][] = ['stock', 'etf'];
+
+  private baseUrl: string;
+
+  constructor(options: YahooFetcherOptions = {}) {
+    super(options);
+    this.baseUrl = options.baseUrl ?? YAHOO_API;
+  }
+
+  protected async fetchHistoricalData(
+    symbol: string,
+    interval: Interval,
+    options?: { startTime?: number; endTime?: number; limit?: number }
+  ): Promise<OHLCV[]> {
+    const normalizedSymbol = this.normalizeSymbol(symbol);
+    const yahooInterval = INTERVAL_MAP[interval];
+
+    let url: string;
+
+    if (options?.startTime && options?.endTime) {
+      // Use period1/period2 for specific time range
+      const period1 = Math.floor(options.startTime / 1000);
+      const period2 = Math.floor(options.endTime / 1000);
+      url = `${this.baseUrl}/chart/${normalizedSymbol}?interval=${yahooInterval}&period1=${period1}&period2=${period2}`;
+    } else {
+      // Use range for default
+      const range = RANGE_MAP[interval];
+      url = `${this.baseUrl}/chart/${normalizedSymbol}?interval=${yahooInterval}&range=${range}`;
+    }
+
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; MaxTrade/1.0)',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Yahoo API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = (await response.json()) as {
+      chart: {
+        result: Array<{
+          timestamp: number[];
+          indicators: {
+            quote: Array<{
+              open: (number | null)[];
+              high: (number | null)[];
+              low: (number | null)[];
+              close: (number | null)[];
+              volume: (number | null)[];
+            }>;
+          };
+        }>;
+        error: { code: string; description: string } | null;
+      };
+    };
+
+    if (data.chart.error) {
+      throw new Error(`Yahoo API error: ${data.chart.error.description}`);
+    }
+
+    const result = data.chart.result[0];
+    if (!result || !result.timestamp) {
+      return [];
+    }
+
+    const quotes = result.indicators.quote[0];
+    const candles: OHLCV[] = [];
+
+    for (let i = 0; i < result.timestamp.length; i++) {
+      // Skip if any value is null (market closed, etc.)
+      if (
+        quotes.open[i] === null ||
+        quotes.high[i] === null ||
+        quotes.low[i] === null ||
+        quotes.close[i] === null
+      ) {
+        continue;
+      }
+
+      candles.push({
+        timestamp: result.timestamp[i] * 1000, // Convert to milliseconds
+        open: quotes.open[i]!,
+        high: quotes.high[i]!,
+        low: quotes.low[i]!,
+        close: quotes.close[i]!,
+        volume: quotes.volume[i] ?? 0,
+      });
+    }
+
+    // Apply limit if specified
+    if (options?.limit && candles.length > options.limit) {
+      return candles.slice(-options.limit);
+    }
+
+    return candles;
+  }
+
+  protected async fetchCurrentPrice(symbol: string): Promise<Quote> {
+    const normalizedSymbol = this.normalizeSymbol(symbol);
+
+    const response = await fetch(
+      `${this.baseUrl}/chart/${normalizedSymbol}?interval=1m&range=1d`,
+      {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; MaxTrade/1.0)',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Yahoo API error: ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      chart: {
+        result: Array<{
+          meta: {
+            regularMarketPrice: number;
+            bid?: number;
+            ask?: number;
+            regularMarketVolume: number;
+          };
+        }>;
+        error: { description: string } | null;
+      };
+    };
+
+    if (data.chart.error) {
+      throw new Error(`Yahoo API error: ${data.chart.error.description}`);
+    }
+
+    const meta = data.chart.result[0]?.meta;
+    if (!meta) {
+      throw new Error(`No data found for ${symbol}`);
+    }
+
+    return {
+      symbol: normalizedSymbol,
+      price: meta.regularMarketPrice,
+      bid: meta.bid ?? meta.regularMarketPrice,
+      ask: meta.ask ?? meta.regularMarketPrice,
+      volume: meta.regularMarketVolume,
+      timestamp: Date.now(),
+    };
+  }
+
+  protected async fetchAssetInfo(symbol: string): Promise<AssetInfo> {
+    const normalizedSymbol = this.normalizeSymbol(symbol);
+
+    // Use quoteSummary for detailed info
+    const response = await fetch(
+      `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${normalizedSymbol}?modules=price,summaryProfile`,
+      {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; MaxTrade/1.0)',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Yahoo API error: ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      quoteSummary: {
+        result: Array<{
+          price: {
+            shortName: string;
+            longName: string;
+            exchange: string;
+            quoteType: string;
+            currency: string;
+            marketCap?: { raw: number };
+          };
+          summaryProfile?: {
+            sector?: string;
+            industry?: string;
+            country?: string;
+          };
+        }>;
+        error: { description: string } | null;
+      };
+    };
+
+    if (data.quoteSummary.error) {
+      throw new Error(`Yahoo API error: ${data.quoteSummary.error.description}`);
+    }
+
+    const result = data.quoteSummary.result[0];
+    if (!result) {
+      throw new Error(`No data found for ${symbol}`);
+    }
+
+    const price = result.price;
+    const profile = result.summaryProfile;
+
+    // Determine asset type
+    let type: AssetInfo['type'] = 'stock';
+    if (price.quoteType === 'ETF') type = 'etf';
+    if (price.quoteType === 'CRYPTOCURRENCY') type = 'crypto';
+
+    return {
+      symbol: normalizedSymbol,
+      name: price.longName || price.shortName || normalizedSymbol,
+      exchange: price.exchange,
+      type,
+      currency: price.currency,
+      metadata: {
+        quoteType: price.quoteType,
+        marketCap: price.marketCap?.raw,
+        sector: profile?.sector,
+        industry: profile?.industry,
+        country: profile?.country,
+      },
+    };
+  }
+
+  protected getHealthCheckSymbol(): string {
+    return 'AAPL';
+  }
+
+  protected normalizeSymbol(symbol: string): string {
+    // Yahoo uses uppercase symbols, dots for class shares
+    return symbol.toUpperCase();
+  }
+}

--- a/tests/fetchers/binance.test.ts
+++ b/tests/fetchers/binance.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Binance Fetcher Tests
+ */
+
+import { describe, test, expect, beforeEach, mock, spyOn } from 'bun:test';
+import { BinanceFetcher } from '../../src/fetchers/binance';
+import { MemoryCache } from '../../src/fetchers/cache';
+
+describe('BinanceFetcher', () => {
+  let fetcher: BinanceFetcher;
+  let cache: MemoryCache;
+
+  beforeEach(() => {
+    cache = new MemoryCache({ defaultTTL: 60000 });
+    fetcher = new BinanceFetcher({ cache });
+  });
+
+  test('should have correct name and supported types', () => {
+    expect(fetcher.name).toBe('binance');
+    expect(fetcher.supportedTypes).toContain('crypto');
+  });
+
+  describe('getHistoricalData', () => {
+    test('should fetch and parse OHLCV data', async () => {
+      const mockData = [
+        [1704067200000, '42000.00', '42500.00', '41800.00', '42300.00', '1000.5'],
+        [1704153600000, '42300.00', '43000.00', '42100.00', '42800.00', '1200.3'],
+      ];
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const result = await fetcher.getHistoricalData('BTCUSDT', '1d');
+
+      expect(result.source).toBe('binance');
+      expect(result.cached).toBe(false);
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]).toEqual({
+        timestamp: 1704067200000,
+        open: 42000,
+        high: 42500,
+        low: 41800,
+        close: 42300,
+        volume: 1000.5,
+      });
+
+      mockFetch.mockRestore();
+    });
+
+    test('should cache results', async () => {
+      const mockData = [[1704067200000, '42000', '42500', '41800', '42300', '1000']];
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      // First call - fetches from API
+      const result1 = await fetcher.getHistoricalData('BTCUSDT', '1d');
+      expect(result1.cached).toBe(false);
+
+      // Second call - from cache
+      const result2 = await fetcher.getHistoricalData('BTCUSDT', '1d');
+      expect(result2.cached).toBe(true);
+
+      // Fetch should only be called once
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      mockFetch.mockRestore();
+    });
+  });
+
+  describe('getCurrentPrice', () => {
+    test('should fetch and parse quote data', async () => {
+      const tickerResponse = { symbol: 'BTCUSDT', price: '42500.00' };
+      const bookResponse = {
+        bidPrice: '42490.00',
+        bidQty: '1.5',
+        askPrice: '42510.00',
+        askQty: '2.0',
+      };
+
+      let callCount = 0;
+      const mockFetch = spyOn(global, 'fetch').mockImplementation(() => {
+        callCount++;
+        const data = callCount === 1 ? tickerResponse : bookResponse;
+        return Promise.resolve(new Response(JSON.stringify(data), { status: 200 }));
+      });
+
+      const result = await fetcher.getCurrentPrice('BTCUSDT');
+
+      expect(result.data.symbol).toBe('BTCUSDT');
+      expect(result.data.price).toBe(42500);
+      expect(result.data.bid).toBe(42490);
+      expect(result.data.ask).toBe(42510);
+
+      mockFetch.mockRestore();
+    });
+  });
+
+  describe('getAssetInfo', () => {
+    test('should fetch and parse exchange info', async () => {
+      const mockData = {
+        symbols: [
+          {
+            symbol: 'BTCUSDT',
+            baseAsset: 'BTC',
+            quoteAsset: 'USDT',
+            status: 'TRADING',
+          },
+        ],
+      };
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const result = await fetcher.getAssetInfo('BTCUSDT');
+
+      expect(result.data.symbol).toBe('BTCUSDT');
+      expect(result.data.name).toBe('BTC/USDT');
+      expect(result.data.exchange).toBe('binance');
+      expect(result.data.type).toBe('crypto');
+      expect(result.data.currency).toBe('USDT');
+
+      mockFetch.mockRestore();
+    });
+  });
+
+  describe('getOrderBook', () => {
+    test('should fetch and parse order book', async () => {
+      const mockData = {
+        lastUpdateId: 12345,
+        bids: [
+          ['42490.00', '1.5'],
+          ['42480.00', '2.0'],
+        ],
+        asks: [
+          ['42510.00', '1.0'],
+          ['42520.00', '3.0'],
+        ],
+      };
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const result = await fetcher.getOrderBook!('BTCUSDT', 10);
+
+      expect(result.data.symbol).toBe('BTCUSDT');
+      expect(result.data.bids).toHaveLength(2);
+      expect(result.data.asks).toHaveLength(2);
+      expect(result.data.bids[0]).toEqual({ price: 42490, quantity: 1.5 });
+
+      mockFetch.mockRestore();
+    });
+  });
+
+  describe('healthCheck', () => {
+    test('should return true when API is healthy', async () => {
+      // healthCheck calls getCurrentPrice which makes 2 fetch calls
+      const tickerResponse = { symbol: 'BTCUSDT', price: '42000.00' };
+      const bookResponse = { bidPrice: '41990.00', askPrice: '42010.00' };
+
+      let callCount = 0;
+      const mockFetch = spyOn(global, 'fetch').mockImplementation(() => {
+        callCount++;
+        const data = callCount === 1 ? tickerResponse : bookResponse;
+        return Promise.resolve(new Response(JSON.stringify(data), { status: 200 }));
+      });
+
+      const healthy = await fetcher.healthCheck();
+      expect(healthy).toBe(true);
+
+      mockFetch.mockRestore();
+    });
+
+    test('should return false when API fails', async () => {
+      const mockFetch = spyOn(global, 'fetch').mockRejectedValue(
+        new Error('Network error')
+      );
+
+      const healthy = await fetcher.healthCheck();
+      expect(healthy).toBe(false);
+
+      mockFetch.mockRestore();
+    });
+  });
+});

--- a/tests/fetchers/cache.test.ts
+++ b/tests/fetchers/cache.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Cache Tests
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { MemoryCache, cacheKey } from '../../src/fetchers/cache';
+
+describe('MemoryCache', () => {
+  let cache: MemoryCache;
+
+  beforeEach(() => {
+    cache = new MemoryCache({ defaultTTL: 1000, maxSize: 100 });
+  });
+
+  test('should store and retrieve values', () => {
+    cache.set('key1', { value: 'test' });
+    expect(cache.get('key1')).toEqual({ value: 'test' });
+  });
+
+  test('should return undefined for missing keys', () => {
+    expect(cache.get('nonexistent')).toBeUndefined();
+  });
+
+  test('should expire entries after TTL', async () => {
+    cache.set('expiring', 'value', 50); // 50ms TTL
+    expect(cache.get('expiring')).toBe('value');
+
+    await new Promise((r) => setTimeout(r, 60));
+    expect(cache.get('expiring')).toBeUndefined();
+  });
+
+  test('should track hit/miss statistics', () => {
+    cache.set('exists', 'value');
+
+    cache.get('exists'); // hit
+    cache.get('exists'); // hit
+    cache.get('missing'); // miss
+
+    const stats = cache.getStats();
+    expect(stats.hits).toBe(2);
+    expect(stats.misses).toBe(1);
+    expect(stats.hitRate).toBeCloseTo(0.667, 2);
+  });
+
+  test('should delete entries', () => {
+    cache.set('toDelete', 'value');
+    expect(cache.has('toDelete')).toBe(true);
+
+    cache.delete('toDelete');
+    expect(cache.has('toDelete')).toBe(false);
+  });
+
+  test('should clear all entries', () => {
+    cache.set('key1', 'value1');
+    cache.set('key2', 'value2');
+
+    cache.clear();
+
+    expect(cache.getStats().size).toBe(0);
+    expect(cache.get('key1')).toBeUndefined();
+  });
+
+  test('should evict oldest when at capacity', () => {
+    const smallCache = new MemoryCache({ defaultTTL: 10000, maxSize: 3 });
+
+    smallCache.set('key1', 'value1');
+    smallCache.set('key2', 'value2');
+    smallCache.set('key3', 'value3');
+    smallCache.set('key4', 'value4'); // Should trigger eviction
+
+    // At least one old key should be evicted
+    const stats = smallCache.getStats();
+    expect(stats.size).toBeLessThanOrEqual(3);
+  });
+
+  test('should cleanup expired entries', async () => {
+    cache.set('short', 'value', 30);
+    cache.set('long', 'value', 10000);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const cleaned = cache.cleanup();
+    expect(cleaned).toBe(1);
+    expect(cache.has('short')).toBe(false);
+    expect(cache.has('long')).toBe(true);
+  });
+});
+
+describe('cacheKey', () => {
+  test('should generate consistent keys', () => {
+    const key = cacheKey('binance', 'historical', 'BTCUSDT', '1h');
+    expect(key).toBe('binance:historical:BTCUSDT:1h');
+  });
+
+  test('should filter undefined values', () => {
+    const key = cacheKey('yahoo', 'quote', 'AAPL', undefined, 100);
+    expect(key).toBe('yahoo:quote:AAPL:100');
+  });
+});

--- a/tests/fetchers/registry.test.ts
+++ b/tests/fetchers/registry.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Fetcher Registry Tests
+ */
+
+import { describe, test, expect, beforeEach, spyOn } from 'bun:test';
+import { fetcherRegistry, initializeDefaultFetchers } from '../../src/fetchers/registry';
+import { BinanceFetcher } from '../../src/fetchers/binance';
+import { YahooFetcher } from '../../src/fetchers/yahoo';
+import type { Fetcher, AssetInfo } from '../../src/fetchers/types';
+
+describe('FetcherRegistry', () => {
+  beforeEach(() => {
+    // Clear registry before each test
+    fetcherRegistry.clear();
+  });
+
+  test('should register and retrieve fetchers', () => {
+    const binance = new BinanceFetcher();
+    fetcherRegistry.register(binance);
+
+    expect(fetcherRegistry.get('binance')).toBe(binance);
+  });
+
+  test('should list registered fetchers', () => {
+    fetcherRegistry.register(new BinanceFetcher());
+    fetcherRegistry.register(new YahooFetcher());
+
+    const names = fetcherRegistry.list();
+    expect(names).toContain('binance');
+    expect(names).toContain('yahoo');
+  });
+
+  test('should return undefined for unknown fetcher', () => {
+    expect(fetcherRegistry.get('unknown')).toBeUndefined();
+  });
+
+  test('should unregister fetchers', () => {
+    fetcherRegistry.register(new BinanceFetcher());
+    expect(fetcherRegistry.get('binance')).toBeDefined();
+
+    fetcherRegistry.unregister('binance');
+    expect(fetcherRegistry.get('binance')).toBeUndefined();
+  });
+
+  test('should get fetchers by type', () => {
+    fetcherRegistry.register(new BinanceFetcher());
+    fetcherRegistry.register(new YahooFetcher());
+
+    const cryptoFetchers = fetcherRegistry.getForType('crypto');
+    expect(cryptoFetchers).toHaveLength(1);
+    expect(cryptoFetchers[0].name).toBe('binance');
+
+    const stockFetchers = fetcherRegistry.getForType('stock');
+    expect(stockFetchers).toHaveLength(1);
+    expect(stockFetchers[0].name).toBe('yahoo');
+  });
+
+  test('should replace duplicate registrations', () => {
+    const fetcher1 = new BinanceFetcher();
+    const fetcher2 = new BinanceFetcher();
+
+    fetcherRegistry.register(fetcher1);
+    fetcherRegistry.register(fetcher2);
+
+    expect(fetcherRegistry.list()).toHaveLength(1);
+    expect(fetcherRegistry.get('binance')).toBe(fetcher2);
+  });
+
+  describe('healthCheckAll', () => {
+    test('should check health of all fetchers', async () => {
+      // Create mock fetchers with controllable health
+      const healthyFetcher: Fetcher = {
+        name: 'healthy',
+        supportedTypes: ['crypto'],
+        getHistoricalData: async () => ({ data: [], source: 'healthy', cached: false, timestamp: 0, latencyMs: 0 }),
+        getCurrentPrice: async () => ({ data: {} as any, source: 'healthy', cached: false, timestamp: 0, latencyMs: 0 }),
+        getAssetInfo: async () => ({ data: {} as any, source: 'healthy', cached: false, timestamp: 0, latencyMs: 0 }),
+        healthCheck: async () => true,
+      };
+
+      const unhealthyFetcher: Fetcher = {
+        name: 'unhealthy',
+        supportedTypes: ['stock'],
+        getHistoricalData: async () => ({ data: [], source: 'unhealthy', cached: false, timestamp: 0, latencyMs: 0 }),
+        getCurrentPrice: async () => ({ data: {} as any, source: 'unhealthy', cached: false, timestamp: 0, latencyMs: 0 }),
+        getAssetInfo: async () => ({ data: {} as any, source: 'unhealthy', cached: false, timestamp: 0, latencyMs: 0 }),
+        healthCheck: async () => false,
+      };
+
+      fetcherRegistry.register(healthyFetcher);
+      fetcherRegistry.register(unhealthyFetcher);
+
+      const results = await fetcherRegistry.healthCheckAll();
+
+      expect(results.get('healthy')).toBe(true);
+      expect(results.get('unhealthy')).toBe(false);
+    });
+
+    test('should handle errors as unhealthy', async () => {
+      const errorFetcher: Fetcher = {
+        name: 'error',
+        supportedTypes: ['crypto'],
+        getHistoricalData: async () => ({ data: [], source: 'error', cached: false, timestamp: 0, latencyMs: 0 }),
+        getCurrentPrice: async () => ({ data: {} as any, source: 'error', cached: false, timestamp: 0, latencyMs: 0 }),
+        getAssetInfo: async () => ({ data: {} as any, source: 'error', cached: false, timestamp: 0, latencyMs: 0 }),
+        healthCheck: async () => {
+          throw new Error('Health check failed');
+        },
+      };
+
+      fetcherRegistry.register(errorFetcher);
+
+      const results = await fetcherRegistry.healthCheckAll();
+      expect(results.get('error')).toBe(false);
+    });
+  });
+});
+
+describe('initializeDefaultFetchers', () => {
+  beforeEach(() => {
+    fetcherRegistry.clear();
+  });
+
+  test('should register binance and yahoo fetchers', async () => {
+    await initializeDefaultFetchers();
+
+    expect(fetcherRegistry.get('binance')).toBeDefined();
+    expect(fetcherRegistry.get('yahoo')).toBeDefined();
+    expect(fetcherRegistry.list()).toHaveLength(2);
+  });
+});

--- a/tests/fetchers/yahoo.test.ts
+++ b/tests/fetchers/yahoo.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Yahoo Fetcher Tests
+ */
+
+import { describe, test, expect, beforeEach, spyOn } from 'bun:test';
+import { YahooFetcher } from '../../src/fetchers/yahoo';
+import { MemoryCache } from '../../src/fetchers/cache';
+
+describe('YahooFetcher', () => {
+  let fetcher: YahooFetcher;
+  let cache: MemoryCache;
+
+  beforeEach(() => {
+    cache = new MemoryCache({ defaultTTL: 60000 });
+    fetcher = new YahooFetcher({ cache });
+  });
+
+  test('should have correct name and supported types', () => {
+    expect(fetcher.name).toBe('yahoo');
+    expect(fetcher.supportedTypes).toContain('stock');
+    expect(fetcher.supportedTypes).toContain('etf');
+  });
+
+  describe('getHistoricalData', () => {
+    test('should fetch and parse OHLCV data', async () => {
+      const mockData = {
+        chart: {
+          result: [
+            {
+              timestamp: [1704067200, 1704153600],
+              indicators: {
+                quote: [
+                  {
+                    open: [185.5, 186.0],
+                    high: [187.0, 188.5],
+                    low: [184.0, 185.5],
+                    close: [186.5, 188.0],
+                    volume: [50000000, 45000000],
+                  },
+                ],
+              },
+            },
+          ],
+          error: null,
+        },
+      };
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const result = await fetcher.getHistoricalData('AAPL', '1d');
+
+      expect(result.source).toBe('yahoo');
+      expect(result.cached).toBe(false);
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]).toEqual({
+        timestamp: 1704067200000, // Converted to ms
+        open: 185.5,
+        high: 187.0,
+        low: 184.0,
+        close: 186.5,
+        volume: 50000000,
+      });
+
+      mockFetch.mockRestore();
+    });
+
+    test('should skip null values', async () => {
+      const mockData = {
+        chart: {
+          result: [
+            {
+              timestamp: [1704067200, 1704153600, 1704240000],
+              indicators: {
+                quote: [
+                  {
+                    open: [185.5, null, 187.0],
+                    high: [187.0, null, 189.0],
+                    low: [184.0, null, 186.0],
+                    close: [186.5, null, 188.5],
+                    volume: [50000000, null, 48000000],
+                  },
+                ],
+              },
+            },
+          ],
+          error: null,
+        },
+      };
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const result = await fetcher.getHistoricalData('AAPL', '1d');
+
+      // Should only have 2 valid candles, skipping the null one
+      expect(result.data).toHaveLength(2);
+
+      mockFetch.mockRestore();
+    });
+
+    test('should apply limit option', async () => {
+      const mockData = {
+        chart: {
+          result: [
+            {
+              timestamp: [1, 2, 3, 4, 5],
+              indicators: {
+                quote: [
+                  {
+                    open: [1, 2, 3, 4, 5],
+                    high: [1, 2, 3, 4, 5],
+                    low: [1, 2, 3, 4, 5],
+                    close: [1, 2, 3, 4, 5],
+                    volume: [1, 2, 3, 4, 5],
+                  },
+                ],
+              },
+            },
+          ],
+          error: null,
+        },
+      };
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const result = await fetcher.getHistoricalData('AAPL', '1d', { limit: 2 });
+
+      expect(result.data).toHaveLength(2);
+      // Should return the last 2 candles
+      expect(result.data[0].timestamp).toBe(4000);
+      expect(result.data[1].timestamp).toBe(5000);
+
+      mockFetch.mockRestore();
+    });
+  });
+
+  describe('getCurrentPrice', () => {
+    test('should fetch and parse quote data', async () => {
+      const mockData = {
+        chart: {
+          result: [
+            {
+              meta: {
+                regularMarketPrice: 188.5,
+                bid: 188.4,
+                ask: 188.6,
+                regularMarketVolume: 45000000,
+              },
+            },
+          ],
+          error: null,
+        },
+      };
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const result = await fetcher.getCurrentPrice('AAPL');
+
+      expect(result.data.symbol).toBe('AAPL');
+      expect(result.data.price).toBe(188.5);
+      expect(result.data.bid).toBe(188.4);
+      expect(result.data.ask).toBe(188.6);
+      expect(result.data.volume).toBe(45000000);
+
+      mockFetch.mockRestore();
+    });
+
+    test('should use price as bid/ask fallback', async () => {
+      const mockData = {
+        chart: {
+          result: [
+            {
+              meta: {
+                regularMarketPrice: 188.5,
+                regularMarketVolume: 45000000,
+                // No bid/ask
+              },
+            },
+          ],
+          error: null,
+        },
+      };
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const result = await fetcher.getCurrentPrice('AAPL');
+
+      expect(result.data.bid).toBe(188.5);
+      expect(result.data.ask).toBe(188.5);
+
+      mockFetch.mockRestore();
+    });
+  });
+
+  describe('getAssetInfo', () => {
+    test('should fetch and parse asset info', async () => {
+      const mockData = {
+        quoteSummary: {
+          result: [
+            {
+              price: {
+                shortName: 'Apple Inc.',
+                longName: 'Apple Inc.',
+                exchange: 'NASDAQ',
+                quoteType: 'EQUITY',
+                currency: 'USD',
+                marketCap: { raw: 2900000000000 },
+              },
+              summaryProfile: {
+                sector: 'Technology',
+                industry: 'Consumer Electronics',
+                country: 'United States',
+              },
+            },
+          ],
+          error: null,
+        },
+      };
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const result = await fetcher.getAssetInfo('AAPL');
+
+      expect(result.data.symbol).toBe('AAPL');
+      expect(result.data.name).toBe('Apple Inc.');
+      expect(result.data.exchange).toBe('NASDAQ');
+      expect(result.data.type).toBe('stock');
+      expect(result.data.currency).toBe('USD');
+      expect(result.data.metadata?.sector).toBe('Technology');
+
+      mockFetch.mockRestore();
+    });
+
+    test('should detect ETF type', async () => {
+      const mockData = {
+        quoteSummary: {
+          result: [
+            {
+              price: {
+                shortName: 'SPDR S&P 500',
+                longName: 'SPDR S&P 500 ETF Trust',
+                exchange: 'NYSE ARCA',
+                quoteType: 'ETF',
+                currency: 'USD',
+              },
+            },
+          ],
+          error: null,
+        },
+      };
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const result = await fetcher.getAssetInfo('SPY');
+
+      expect(result.data.type).toBe('etf');
+
+      mockFetch.mockRestore();
+    });
+  });
+
+  describe('healthCheck', () => {
+    test('should return true when API is healthy', async () => {
+      const mockData = {
+        chart: {
+          result: [{ meta: { regularMarketPrice: 188.5, regularMarketVolume: 1000 } }],
+          error: null,
+        },
+      };
+
+      const mockFetch = spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(mockData), { status: 200 })
+      );
+
+      const healthy = await fetcher.healthCheck();
+      expect(healthy).toBe(true);
+
+      mockFetch.mockRestore();
+    });
+
+    test('should return false when API fails', async () => {
+      const mockFetch = spyOn(global, 'fetch').mockRejectedValue(
+        new Error('Network error')
+      );
+
+      const healthy = await fetcher.healthCheck();
+      expect(healthy).toBe(false);
+
+      mockFetch.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Issue #1 - Data Ingestion Layer:

- **Base Fetcher interface** with types (OHLCV, Quote, AssetInfo, OrderBook)
- **BinanceFetcher** for crypto data (historical, real-time, WebSocket, order book)
- **YahooFetcher** for stocks/ETFs (historical up to 10yr, quotes, asset info)
- **MemoryCache** with TTL and hit/miss statistics
- **FetcherRegistry** service locator for managing data sources

## Test plan

- [x] 37 unit tests passing
- [ ] Integration test with live APIs (manual verification)
- [ ] Verify cache hit rate > 80%
- [ ] Verify latency < 5s for real-time data

## Technical notes

Patterns from QuantMuse:
- Dataclass-style immutable interfaces
- ABC pattern for base fetcher
- Service locator for registry
- Graceful degradation (cache fallback)

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)