### PR TITLE
feat(backtest): implement backtesting engine with commission-aware simulation

### DIFF
--- a/src/backtest/engine.ts
+++ b/src/backtest/engine.ts
@@ -1,0 +1,418 @@
+/**
+ * Backtest Engine
+ * Core simulation engine for strategy backtesting
+ */
+
+import type {
+  BacktestConfig,
+  BacktestResult,
+  BacktestData,
+  EquityPoint,
+  PriceBar,
+  Trade,
+  Position,
+} from './types';
+import type { Signal, StrategyResult } from '../strategies/types';
+import { Portfolio, DEFAULT_COMMISSION, DEFAULT_SLIPPAGE } from './portfolio';
+import {
+  calculateMetrics,
+  calculateBenchmarkComparison,
+  calculateMonthlyReturns,
+} from './metrics';
+
+/** Default backtest configuration */
+export const DEFAULT_CONFIG: BacktestConfig = {
+  initialCapital: 100000,
+  commission: DEFAULT_COMMISSION,
+  slippage: DEFAULT_SLIPPAGE,
+  positionSizing: 'equal_weight',
+  maxPositions: 20,
+  maxPositionPercent: 10,
+  rebalanceFrequency: 'daily',
+  allowFractional: false,
+  riskFreeRate: 0.02,
+};
+
+export class BacktestEngine {
+  private config: BacktestConfig;
+  private portfolio: Portfolio;
+  private equityCurve: EquityPoint[] = [];
+  private benchmarkPrices: number[] = [];
+
+  constructor(config: Partial<BacktestConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.portfolio = new Portfolio(
+      this.config.initialCapital,
+      this.config.commission,
+      this.config.slippage,
+      this.config.allowFractional
+    );
+  }
+
+  /**
+   * Run backtest with signals from a strategy
+   */
+  run(
+    data: BacktestData,
+    signalGenerator: (date: number, prices: Map<string, PriceBar>) => Signal[]
+  ): BacktestResult {
+    // Reset state
+    this.portfolio.reset(this.config.initialCapital);
+    this.equityCurve = [];
+    this.benchmarkPrices = [];
+
+    // Get all unique dates
+    const allDates = this.getUniqueDates(data.prices);
+    const tradingDates = allDates.filter(
+      (d) => d >= data.startDate && d <= data.endDate
+    );
+
+    if (tradingDates.length === 0) {
+      return this.createEmptyResult();
+    }
+
+    // Run simulation
+    let prevEquity = this.config.initialCapital;
+
+    for (let i = 0; i < tradingDates.length; i++) {
+      const date = tradingDates[i];
+      const currentPrices = this.getPricesForDate(data.prices, date);
+
+      // Update portfolio prices
+      this.portfolio.updatePrices(currentPrices, date);
+
+      // Check if we should rebalance
+      const shouldRebalance = this.shouldRebalance(i, tradingDates);
+
+      if (shouldRebalance) {
+        // Generate signals
+        const priceBars = this.getPriceBarsForDate(data.prices, date);
+        const signals = signalGenerator(date, priceBars);
+
+        // Execute signals
+        this.executeSignals(signals, currentPrices, date);
+      }
+
+      // Record equity point
+      const equity = this.portfolio.getTotalValue();
+      const cash = this.portfolio.getCash();
+      const dailyReturn = prevEquity > 0 ? ((equity - prevEquity) / prevEquity) * 100 : 0;
+      const cumulativeReturn =
+        ((equity - this.config.initialCapital) / this.config.initialCapital) * 100;
+
+      // Calculate drawdown
+      const peak = Math.max(
+        this.config.initialCapital,
+        ...this.equityCurve.map((p) => p.equity)
+      );
+      const drawdown = ((peak - equity) / peak) * 100;
+
+      this.equityCurve.push({
+        date,
+        equity,
+        cash,
+        invested: equity - cash,
+        dailyReturn,
+        cumulativeReturn,
+        drawdown,
+      });
+
+      // Track benchmark if available
+      if (data.prices.has('SPY') || data.prices.has('benchmark')) {
+        const benchmarkSymbol = data.prices.has('SPY') ? 'SPY' : 'benchmark';
+        const benchmarkPrice = currentPrices.get(benchmarkSymbol);
+        if (benchmarkPrice) {
+          this.benchmarkPrices.push(benchmarkPrice);
+        }
+      }
+
+      prevEquity = equity;
+    }
+
+    // Close all positions at end
+    const finalDate = tradingDates[tradingDates.length - 1];
+    const finalPrices = this.getPricesForDate(data.prices, finalDate);
+    this.portfolio.closeAll(finalPrices, finalDate);
+
+    // Calculate final metrics
+    return this.createResult();
+  }
+
+  /**
+   * Run backtest with pre-generated strategy results
+   */
+  runWithStrategy(
+    data: BacktestData,
+    strategyResults: Map<number, StrategyResult>
+  ): BacktestResult {
+    return this.run(data, (date) => {
+      const result = strategyResults.get(date);
+      return result?.signals ?? [];
+    });
+  }
+
+  /**
+   * Execute signals
+   */
+  private executeSignals(
+    signals: Signal[],
+    prices: Map<string, number>,
+    date: number
+  ): void {
+    // Sort by confidence (highest first)
+    const sortedSignals = [...signals].sort((a, b) => b.confidence - a.confidence);
+
+    // Process sell signals first
+    const sellSignals = sortedSignals.filter((s) => s.action === 'sell');
+    for (const signal of sellSignals) {
+      const price = prices.get(signal.symbol);
+      const position = this.portfolio.getPosition(signal.symbol);
+
+      if (price && position && position.quantity > 0) {
+        this.portfolio.sell(signal.symbol, position.quantity, price, date);
+      }
+    }
+
+    // Process buy signals
+    const buySignals = sortedSignals.filter((s) => s.action === 'buy');
+    const currentPositions = this.portfolio.getPositions();
+
+    // Calculate how many new positions we can open
+    const availableSlots = this.config.maxPositions - currentPositions.length;
+    const signalsToExecute = buySignals.slice(0, availableSlots);
+
+    for (const signal of signalsToExecute) {
+      const price = prices.get(signal.symbol);
+      if (!price) continue;
+
+      // Check if we already have this position
+      if (this.portfolio.getPosition(signal.symbol)) continue;
+
+      // Calculate position size
+      const quantity = this.calculatePositionSize(
+        signal,
+        price,
+        signalsToExecute.length
+      );
+
+      if (quantity > 0) {
+        this.portfolio.buy(signal.symbol, quantity, price, date);
+      }
+    }
+  }
+
+  /**
+   * Calculate position size based on config
+   */
+  private calculatePositionSize(
+    signal: Signal,
+    price: number,
+    totalSignals: number
+  ): number {
+    const portfolioValue = this.portfolio.getTotalValue();
+    const cash = this.portfolio.getCash();
+    let targetValue: number;
+
+    switch (this.config.positionSizing) {
+      case 'fixed':
+        targetValue = this.config.fixedPositionSize ?? 10000;
+        break;
+
+      case 'percent':
+        targetValue = portfolioValue * ((this.config.positionSizePercent ?? 5) / 100);
+        break;
+
+      case 'equal_weight':
+        // Divide available capital equally among signals
+        targetValue = cash / Math.max(1, totalSignals);
+        break;
+
+      case 'kelly':
+        // Simplified Kelly: use confidence as win probability
+        const kellyFraction = signal.confidence - (1 - signal.confidence);
+        targetValue = portfolioValue * Math.max(0, kellyFraction * 0.25); // Quarter Kelly
+        break;
+
+      default:
+        targetValue = portfolioValue * 0.05;
+    }
+
+    // Apply max position constraint
+    const maxValue = portfolioValue * (this.config.maxPositionPercent / 100);
+    targetValue = Math.min(targetValue, maxValue, cash);
+
+    return targetValue / price;
+  }
+
+  /**
+   * Check if we should rebalance on this date
+   */
+  private shouldRebalance(dayIndex: number, dates: number[]): boolean {
+    if (dayIndex === 0) return true; // Always trade on first day
+
+    switch (this.config.rebalanceFrequency) {
+      case 'daily':
+        return true;
+
+      case 'weekly':
+        // Check if week changed
+        const prevWeek = this.getWeekNumber(dates[dayIndex - 1]);
+        const currWeek = this.getWeekNumber(dates[dayIndex]);
+        return prevWeek !== currWeek;
+
+      case 'monthly':
+        // Check if month changed
+        const prevMonth = new Date(dates[dayIndex - 1]).getMonth();
+        const currMonth = new Date(dates[dayIndex]).getMonth();
+        return prevMonth !== currMonth;
+
+      case 'quarterly':
+        const prevQuarter = Math.floor(new Date(dates[dayIndex - 1]).getMonth() / 3);
+        const currQuarter = Math.floor(new Date(dates[dayIndex]).getMonth() / 3);
+        return prevQuarter !== currQuarter;
+
+      case 'never':
+        return dayIndex === 0;
+
+      default:
+        return true;
+    }
+  }
+
+  /**
+   * Get week number from timestamp
+   */
+  private getWeekNumber(timestamp: number): number {
+    const date = new Date(timestamp);
+    const firstDay = new Date(date.getFullYear(), 0, 1);
+    const days = Math.floor((date.getTime() - firstDay.getTime()) / (24 * 60 * 60 * 1000));
+    return Math.ceil((days + firstDay.getDay() + 1) / 7);
+  }
+
+  /**
+   * Get all unique dates from price data
+   */
+  private getUniqueDates(prices: Map<string, PriceBar[]>): number[] {
+    const dateSet = new Set<number>();
+
+    for (const bars of prices.values()) {
+      for (const bar of bars) {
+        dateSet.add(bar.timestamp);
+      }
+    }
+
+    return Array.from(dateSet).sort((a, b) => a - b);
+  }
+
+  /**
+   * Get closing prices for a specific date
+   */
+  private getPricesForDate(
+    prices: Map<string, PriceBar[]>,
+    date: number
+  ): Map<string, number> {
+    const result = new Map<string, number>();
+
+    for (const [symbol, bars] of prices) {
+      const bar = bars.find((b) => b.timestamp === date);
+      if (bar) {
+        result.set(symbol, bar.close);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Get full price bars for a specific date
+   */
+  private getPriceBarsForDate(
+    prices: Map<string, PriceBar[]>,
+    date: number
+  ): Map<string, PriceBar> {
+    const result = new Map<string, PriceBar>();
+
+    for (const [symbol, bars] of prices) {
+      const bar = bars.find((b) => b.timestamp === date);
+      if (bar) {
+        result.set(symbol, bar);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Create backtest result
+   */
+  private createResult(): BacktestResult {
+    const trades = this.portfolio.getTrades();
+    const metrics = calculateMetrics(
+      this.equityCurve,
+      trades,
+      this.config.initialCapital,
+      this.config.riskFreeRate
+    );
+
+    const benchmark = this.benchmarkPrices.length > 0
+      ? calculateBenchmarkComparison(
+          this.equityCurve,
+          this.benchmarkPrices,
+          this.config.riskFreeRate
+        )
+      : undefined;
+
+    const monthlyReturns = calculateMonthlyReturns(this.equityCurve);
+
+    return {
+      config: { ...this.config },
+      metrics,
+      benchmark,
+      equityCurve: this.equityCurve,
+      monthlyReturns,
+      trades,
+      finalPositions: this.portfolio.getPositions(),
+    };
+  }
+
+  /**
+   * Create empty result
+   */
+  private createEmptyResult(): BacktestResult {
+    return {
+      config: { ...this.config },
+      metrics: calculateMetrics([], [], this.config.initialCapital),
+      equityCurve: [],
+      monthlyReturns: [],
+      trades: [],
+      finalPositions: [],
+    };
+  }
+
+  /**
+   * Get current configuration
+   */
+  getConfig(): BacktestConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Update configuration
+   */
+  setConfig(config: Partial<BacktestConfig>): void {
+    this.config = { ...this.config, ...config };
+    this.portfolio = new Portfolio(
+      this.config.initialCapital,
+      this.config.commission,
+      this.config.slippage,
+      this.config.allowFractional
+    );
+  }
+}
+
+/** Create a new backtest engine */
+export function createBacktestEngine(
+  config: Partial<BacktestConfig> = {}
+): BacktestEngine {
+  return new BacktestEngine(config);
+}

--- a/src/backtest/index.ts
+++ b/src/backtest/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Backtesting Module
+ * Commission-aware simulation with performance analytics
+ */
+
+// Types
+export type {
+  Trade,
+  TradeSide,
+  TradeStatus,
+  Position,
+  PortfolioSnapshot,
+  CommissionConfig,
+  SlippageConfig,
+  BacktestConfig,
+  PerformanceMetrics,
+  BenchmarkComparison,
+  EquityPoint,
+  MonthlyReturn,
+  BacktestResult,
+  PriceBar,
+  BacktestData,
+  PositionSizing,
+  RebalanceFrequency,
+} from './types';
+
+// Portfolio management
+export {
+  Portfolio,
+  DEFAULT_COMMISSION,
+  DEFAULT_SLIPPAGE,
+} from './portfolio';
+
+// Metrics calculation
+export {
+  calculateMetrics,
+  calculateBenchmarkComparison,
+  calculateMonthlyReturns,
+} from './metrics';
+
+// Engine
+export {
+  BacktestEngine,
+  createBacktestEngine,
+  DEFAULT_CONFIG,
+} from './engine';

--- a/src/backtest/metrics.ts
+++ b/src/backtest/metrics.ts
@@ -1,0 +1,446 @@
+/**
+ * Performance Metrics Calculator
+ * Comprehensive backtest performance analysis
+ */
+
+import type {
+  PerformanceMetrics,
+  BenchmarkComparison,
+  Trade,
+  EquityPoint,
+  MonthlyReturn,
+} from './types';
+
+/** Calculate all performance metrics */
+export function calculateMetrics(
+  equityCurve: EquityPoint[],
+  trades: Trade[],
+  initialCapital: number,
+  riskFreeRate = 0.02
+): PerformanceMetrics {
+  if (equityCurve.length === 0) {
+    return createEmptyMetrics();
+  }
+
+  const finalValue = equityCurve[equityCurve.length - 1].equity;
+  const startDate = equityCurve[0].date;
+  const endDate = equityCurve[equityCurve.length - 1].date;
+  const tradingDays = equityCurve.length;
+
+  // Returns
+  const totalReturn = finalValue - initialCapital;
+  const totalReturnPercent = (totalReturn / initialCapital) * 100;
+
+  const years = tradingDays / 252;
+  const cagr = years > 0 ? (Math.pow(finalValue / initialCapital, 1 / years) - 1) * 100 : 0;
+
+  // Daily returns for volatility calculation
+  const dailyReturns = equityCurve
+    .slice(1)
+    .map((point, i) => (point.equity - equityCurve[i].equity) / equityCurve[i].equity);
+
+  const volatility = calculateVolatility(dailyReturns) * 100;
+
+  // Risk-adjusted returns
+  const sharpeRatio = calculateSharpeRatio(dailyReturns, riskFreeRate);
+  const sortinoRatio = calculateSortinoRatio(dailyReturns, riskFreeRate);
+
+  // Drawdown analysis
+  const { maxDrawdown, maxDrawdownDuration, avgDrawdown } = calculateDrawdownMetrics(equityCurve);
+
+  const calmarRatio = maxDrawdown !== 0 ? cagr / maxDrawdown : 0;
+
+  // Trade statistics
+  const tradeStats = calculateTradeStats(trades);
+
+  return {
+    totalReturn,
+    totalReturnPercent,
+    annualizedReturn: cagr,
+    cagr,
+    volatility,
+    sharpeRatio,
+    sortinoRatio,
+    calmarRatio,
+    maxDrawdown,
+    maxDrawdownDuration,
+    avgDrawdown,
+    ...tradeStats,
+    tradingDays,
+    startDate,
+    endDate,
+    finalValue,
+  };
+}
+
+/** Calculate annualized volatility from daily returns */
+function calculateVolatility(dailyReturns: number[]): number {
+  if (dailyReturns.length < 2) return 0;
+
+  const mean = dailyReturns.reduce((a, b) => a + b, 0) / dailyReturns.length;
+  const squaredDiffs = dailyReturns.map((r) => Math.pow(r - mean, 2));
+  const variance = squaredDiffs.reduce((a, b) => a + b, 0) / (dailyReturns.length - 1);
+
+  return Math.sqrt(variance * 252); // Annualize
+}
+
+/** Calculate Sharpe Ratio */
+function calculateSharpeRatio(dailyReturns: number[], annualRiskFreeRate: number): number {
+  if (dailyReturns.length < 2) return 0;
+
+  const dailyRiskFree = annualRiskFreeRate / 252;
+  const excessReturns = dailyReturns.map((r) => r - dailyRiskFree);
+
+  const avgExcessReturn = excessReturns.reduce((a, b) => a + b, 0) / excessReturns.length;
+  const volatility = calculateVolatility(excessReturns);
+
+  if (volatility === 0) return 0;
+
+  return (avgExcessReturn * 252) / volatility;
+}
+
+/** Calculate Sortino Ratio */
+function calculateSortinoRatio(dailyReturns: number[], annualRiskFreeRate: number): number {
+  if (dailyReturns.length < 2) return 0;
+
+  const dailyRiskFree = annualRiskFreeRate / 252;
+  const excessReturns = dailyReturns.map((r) => r - dailyRiskFree);
+
+  const avgExcessReturn = excessReturns.reduce((a, b) => a + b, 0) / excessReturns.length;
+
+  // Downside deviation
+  const negativeReturns = excessReturns.filter((r) => r < 0);
+  if (negativeReturns.length < 2) return avgExcessReturn > 0 ? Infinity : 0;
+
+  const downsideSquared = negativeReturns.map((r) => r * r);
+  const downsideVariance = downsideSquared.reduce((a, b) => a + b, 0) / negativeReturns.length;
+  const downsideDeviation = Math.sqrt(downsideVariance * 252);
+
+  if (downsideDeviation === 0) return 0;
+
+  return (avgExcessReturn * 252) / downsideDeviation;
+}
+
+/** Calculate drawdown metrics */
+function calculateDrawdownMetrics(equityCurve: EquityPoint[]): {
+  maxDrawdown: number;
+  maxDrawdownDuration: number;
+  avgDrawdown: number;
+} {
+  if (equityCurve.length === 0) {
+    return { maxDrawdown: 0, maxDrawdownDuration: 0, avgDrawdown: 0 };
+  }
+
+  let peak = equityCurve[0].equity;
+  let maxDrawdown = 0;
+  let currentDrawdownStart = 0;
+  let maxDrawdownDuration = 0;
+  let drawdowns: number[] = [];
+
+  for (let i = 0; i < equityCurve.length; i++) {
+    const equity = equityCurve[i].equity;
+
+    if (equity > peak) {
+      // New peak - record drawdown duration
+      if (currentDrawdownStart > 0) {
+        const duration = i - currentDrawdownStart;
+        maxDrawdownDuration = Math.max(maxDrawdownDuration, duration);
+        currentDrawdownStart = 0;
+      }
+      peak = equity;
+    } else {
+      const drawdown = ((peak - equity) / peak) * 100;
+      drawdowns.push(drawdown);
+
+      if (drawdown > maxDrawdown) {
+        maxDrawdown = drawdown;
+      }
+
+      if (currentDrawdownStart === 0) {
+        currentDrawdownStart = i;
+      }
+    }
+  }
+
+  // Check final drawdown duration
+  if (currentDrawdownStart > 0) {
+    maxDrawdownDuration = Math.max(
+      maxDrawdownDuration,
+      equityCurve.length - currentDrawdownStart
+    );
+  }
+
+  const avgDrawdown = drawdowns.length > 0
+    ? drawdowns.reduce((a, b) => a + b, 0) / drawdowns.length
+    : 0;
+
+  return { maxDrawdown, maxDrawdownDuration, avgDrawdown };
+}
+
+/** Calculate trade statistics */
+function calculateTradeStats(trades: Trade[]): {
+  totalTrades: number;
+  winningTrades: number;
+  losingTrades: number;
+  winRate: number;
+  profitFactor: number;
+  avgWin: number;
+  avgLoss: number;
+  avgWinLossRatio: number;
+  largestWin: number;
+  largestLoss: number;
+  avgHoldingPeriod: number;
+} {
+  // Only count sell trades (completed round trips)
+  const closedTrades = trades.filter((t) => t.side === 'sell' && t.pnl !== undefined);
+
+  if (closedTrades.length === 0) {
+    return {
+      totalTrades: trades.length,
+      winningTrades: 0,
+      losingTrades: 0,
+      winRate: 0,
+      profitFactor: 0,
+      avgWin: 0,
+      avgLoss: 0,
+      avgWinLossRatio: 0,
+      largestWin: 0,
+      largestLoss: 0,
+      avgHoldingPeriod: 0,
+    };
+  }
+
+  const winningTrades = closedTrades.filter((t) => t.pnl! > 0);
+  const losingTrades = closedTrades.filter((t) => t.pnl! <= 0);
+
+  const totalWin = winningTrades.reduce((sum, t) => sum + t.pnl!, 0);
+  const totalLoss = Math.abs(losingTrades.reduce((sum, t) => sum + t.pnl!, 0));
+
+  const avgWin = winningTrades.length > 0 ? totalWin / winningTrades.length : 0;
+  const avgLoss = losingTrades.length > 0 ? totalLoss / losingTrades.length : 0;
+
+  const largestWin = winningTrades.length > 0
+    ? Math.max(...winningTrades.map((t) => t.pnl!))
+    : 0;
+  const largestLoss = losingTrades.length > 0
+    ? Math.abs(Math.min(...losingTrades.map((t) => t.pnl!)))
+    : 0;
+
+  const avgHoldingPeriod = closedTrades
+    .filter((t) => t.holdingPeriodDays !== undefined)
+    .reduce((sum, t) => sum + t.holdingPeriodDays!, 0) / closedTrades.length || 0;
+
+  return {
+    totalTrades: trades.length,
+    winningTrades: winningTrades.length,
+    losingTrades: losingTrades.length,
+    winRate: (winningTrades.length / closedTrades.length) * 100,
+    profitFactor: totalLoss > 0 ? totalWin / totalLoss : totalWin > 0 ? Infinity : 0,
+    avgWin,
+    avgLoss,
+    avgWinLossRatio: avgLoss > 0 ? avgWin / avgLoss : avgWin > 0 ? Infinity : 0,
+    largestWin,
+    largestLoss,
+    avgHoldingPeriod,
+  };
+}
+
+/** Calculate benchmark comparison */
+export function calculateBenchmarkComparison(
+  equityCurve: EquityPoint[],
+  benchmarkPrices: number[],
+  riskFreeRate = 0.02
+): BenchmarkComparison {
+  if (equityCurve.length < 2 || benchmarkPrices.length < 2) {
+    return createEmptyBenchmark();
+  }
+
+  // Align lengths
+  const minLen = Math.min(equityCurve.length, benchmarkPrices.length);
+  const equity = equityCurve.slice(0, minLen);
+  const benchmark = benchmarkPrices.slice(0, minLen);
+
+  // Strategy returns
+  const strategyReturns = equity
+    .slice(1)
+    .map((point, i) => (point.equity - equity[i].equity) / equity[i].equity);
+
+  // Benchmark returns
+  const benchmarkReturns = benchmark
+    .slice(1)
+    .map((price, i) => (price - benchmark[i]) / benchmark[i]);
+
+  // Benchmark metrics
+  const benchmarkReturn = ((benchmark[benchmark.length - 1] / benchmark[0]) - 1) * 100;
+  const benchmarkVolatility = calculateVolatility(benchmarkReturns) * 100;
+  const benchmarkSharpe = calculateSharpeRatio(benchmarkReturns, riskFreeRate);
+
+  // Benchmark max drawdown
+  let peak = benchmark[0];
+  let maxDD = 0;
+  for (const price of benchmark) {
+    if (price > peak) peak = price;
+    const dd = (peak - price) / peak;
+    if (dd > maxDD) maxDD = dd;
+  }
+  const benchmarkMaxDrawdown = maxDD * 100;
+
+  // Correlation and Beta
+  const correlation = calculateCorrelation(strategyReturns, benchmarkReturns);
+  const beta = calculateBeta(strategyReturns, benchmarkReturns);
+
+  // Alpha (Jensen's Alpha)
+  const avgStrategyReturn = strategyReturns.reduce((a, b) => a + b, 0) / strategyReturns.length * 252;
+  const avgBenchmarkReturn = benchmarkReturns.reduce((a, b) => a + b, 0) / benchmarkReturns.length * 252;
+  const alpha = avgStrategyReturn - (riskFreeRate + beta * (avgBenchmarkReturn - riskFreeRate));
+
+  // Tracking error
+  const excessReturns = strategyReturns.map((r, i) => r - benchmarkReturns[i]);
+  const trackingError = calculateVolatility(excessReturns) * 100;
+
+  // Information ratio
+  const avgExcess = excessReturns.reduce((a, b) => a + b, 0) / excessReturns.length * 252 * 100;
+  const informationRatio = trackingError > 0 ? avgExcess / trackingError : 0;
+
+  // Excess return
+  const strategyReturn = ((equity[equity.length - 1].equity / equity[0].equity) - 1) * 100;
+  const excessReturn = strategyReturn - benchmarkReturn;
+
+  return {
+    benchmarkReturn,
+    benchmarkVolatility,
+    benchmarkSharpe,
+    benchmarkMaxDrawdown,
+    alpha: alpha * 100,
+    beta,
+    correlation,
+    informationRatio,
+    trackingError,
+    excessReturn,
+  };
+}
+
+/** Calculate Pearson correlation */
+function calculateCorrelation(x: number[], y: number[]): number {
+  if (x.length !== y.length || x.length < 2) return 0;
+
+  const n = x.length;
+  const meanX = x.reduce((a, b) => a + b, 0) / n;
+  const meanY = y.reduce((a, b) => a + b, 0) / n;
+
+  let cov = 0;
+  let varX = 0;
+  let varY = 0;
+
+  for (let i = 0; i < n; i++) {
+    const dx = x[i] - meanX;
+    const dy = y[i] - meanY;
+    cov += dx * dy;
+    varX += dx * dx;
+    varY += dy * dy;
+  }
+
+  const denom = Math.sqrt(varX * varY);
+  return denom > 0 ? cov / denom : 0;
+}
+
+/** Calculate Beta */
+function calculateBeta(strategyReturns: number[], benchmarkReturns: number[]): number {
+  if (strategyReturns.length !== benchmarkReturns.length || strategyReturns.length < 2) {
+    return 1;
+  }
+
+  const n = strategyReturns.length;
+  const meanStrategy = strategyReturns.reduce((a, b) => a + b, 0) / n;
+  const meanBenchmark = benchmarkReturns.reduce((a, b) => a + b, 0) / n;
+
+  let cov = 0;
+  let varBenchmark = 0;
+
+  for (let i = 0; i < n; i++) {
+    const ds = strategyReturns[i] - meanStrategy;
+    const db = benchmarkReturns[i] - meanBenchmark;
+    cov += ds * db;
+    varBenchmark += db * db;
+  }
+
+  return varBenchmark > 0 ? cov / varBenchmark : 1;
+}
+
+/** Generate monthly returns table */
+export function calculateMonthlyReturns(equityCurve: EquityPoint[]): MonthlyReturn[] {
+  if (equityCurve.length === 0) return [];
+
+  const monthlyReturns: MonthlyReturn[] = [];
+  const monthlyData: Map<string, { start: number; end: number }> = new Map();
+
+  for (const point of equityCurve) {
+    const date = new Date(point.date);
+    const key = `${date.getFullYear()}-${date.getMonth()}`;
+
+    if (!monthlyData.has(key)) {
+      monthlyData.set(key, { start: point.equity, end: point.equity });
+    } else {
+      monthlyData.get(key)!.end = point.equity;
+    }
+  }
+
+  for (const [key, data] of monthlyData) {
+    const [year, month] = key.split('-').map(Number);
+    const ret = ((data.end / data.start) - 1) * 100;
+    monthlyReturns.push({ year, month, return: ret });
+  }
+
+  return monthlyReturns.sort((a, b) => {
+    if (a.year !== b.year) return a.year - b.year;
+    return a.month - b.month;
+  });
+}
+
+/** Create empty metrics object */
+function createEmptyMetrics(): PerformanceMetrics {
+  return {
+    totalReturn: 0,
+    totalReturnPercent: 0,
+    annualizedReturn: 0,
+    cagr: 0,
+    volatility: 0,
+    sharpeRatio: 0,
+    sortinoRatio: 0,
+    calmarRatio: 0,
+    maxDrawdown: 0,
+    maxDrawdownDuration: 0,
+    avgDrawdown: 0,
+    totalTrades: 0,
+    winningTrades: 0,
+    losingTrades: 0,
+    winRate: 0,
+    profitFactor: 0,
+    avgWin: 0,
+    avgLoss: 0,
+    avgWinLossRatio: 0,
+    largestWin: 0,
+    largestLoss: 0,
+    avgHoldingPeriod: 0,
+    tradingDays: 0,
+    startDate: 0,
+    endDate: 0,
+    finalValue: 0,
+  };
+}
+
+/** Create empty benchmark comparison */
+function createEmptyBenchmark(): BenchmarkComparison {
+  return {
+    benchmarkReturn: 0,
+    benchmarkVolatility: 0,
+    benchmarkSharpe: 0,
+    benchmarkMaxDrawdown: 0,
+    alpha: 0,
+    beta: 1,
+    correlation: 0,
+    informationRatio: 0,
+    trackingError: 0,
+    excessReturn: 0,
+  };
+}

--- a/src/backtest/portfolio.ts
+++ b/src/backtest/portfolio.ts
@@ -1,0 +1,323 @@
+/**
+ * Portfolio Manager
+ * Handles positions, trades, and P&L tracking
+ */
+
+import type {
+  Position,
+  Trade,
+  TradeSide,
+  CommissionConfig,
+  SlippageConfig,
+  PortfolioSnapshot,
+} from './types';
+
+let tradeIdCounter = 0;
+
+/** Generate unique trade ID */
+function generateTradeId(): string {
+  return `T${++tradeIdCounter}-${Date.now()}`;
+}
+
+/** Default commission config */
+export const DEFAULT_COMMISSION: CommissionConfig = {
+  fixedFee: 0,
+  percentFee: 0.001, // 0.1%
+  minCommission: 0,
+  maxCommission: Infinity,
+};
+
+/** Default slippage config */
+export const DEFAULT_SLIPPAGE: SlippageConfig = {
+  fixed: 0,
+  percent: 0.0005, // 0.05%
+  randomize: false,
+};
+
+export class Portfolio {
+  private cash: number;
+  private positions: Map<string, Position> = new Map();
+  private trades: Trade[] = [];
+  private commissionConfig: CommissionConfig;
+  private slippageConfig: SlippageConfig;
+  private allowFractional: boolean;
+
+  constructor(
+    initialCapital: number,
+    commission: CommissionConfig = DEFAULT_COMMISSION,
+    slippage: SlippageConfig = DEFAULT_SLIPPAGE,
+    allowFractional = false
+  ) {
+    this.cash = initialCapital;
+    this.commissionConfig = commission;
+    this.slippageConfig = slippage;
+    this.allowFractional = allowFractional;
+  }
+
+  /** Get current cash balance */
+  getCash(): number {
+    return this.cash;
+  }
+
+  /** Get all open positions */
+  getPositions(): Position[] {
+    return Array.from(this.positions.values());
+  }
+
+  /** Get position for a symbol */
+  getPosition(symbol: string): Position | undefined {
+    return this.positions.get(symbol);
+  }
+
+  /** Get all executed trades */
+  getTrades(): Trade[] {
+    return [...this.trades];
+  }
+
+  /** Calculate commission for a trade */
+  calculateCommission(quantity: number, price: number): number {
+    const value = Math.abs(quantity * price);
+    let commission = this.commissionConfig.fixedFee + value * this.commissionConfig.percentFee;
+
+    commission = Math.max(commission, this.commissionConfig.minCommission);
+    commission = Math.min(commission, this.commissionConfig.maxCommission);
+
+    return commission;
+  }
+
+  /** Calculate slippage for a trade */
+  calculateSlippage(price: number, side: TradeSide): number {
+    let slippage = this.slippageConfig.fixed + price * this.slippageConfig.percent;
+
+    if (this.slippageConfig.randomize) {
+      slippage *= 0.5 + Math.random(); // 50% - 150% variation
+    }
+
+    // Slippage is adverse: buy higher, sell lower
+    return side === 'buy' ? slippage : -slippage;
+  }
+
+  /** Execute a buy order */
+  buy(
+    symbol: string,
+    quantity: number,
+    price: number,
+    timestamp: number
+  ): Trade | null {
+    if (quantity <= 0) return null;
+
+    // Apply slippage
+    const slippage = this.calculateSlippage(price, 'buy');
+    const executionPrice = price + slippage;
+
+    // Round quantity if not allowing fractional
+    const finalQuantity = this.allowFractional
+      ? quantity
+      : Math.floor(quantity);
+
+    if (finalQuantity <= 0) return null;
+
+    // Calculate costs
+    const tradeValue = finalQuantity * executionPrice;
+    const commission = this.calculateCommission(finalQuantity, executionPrice);
+    const totalCost = tradeValue + commission;
+
+    // Check if we have enough cash
+    if (totalCost > this.cash) {
+      return null;
+    }
+
+    // Deduct from cash
+    this.cash -= totalCost;
+
+    // Update or create position
+    const existingPosition = this.positions.get(symbol);
+
+    if (existingPosition) {
+      // Average cost calculation
+      const totalQuantity = existingPosition.quantity + finalQuantity;
+      const totalCostBasis =
+        existingPosition.quantity * existingPosition.avgCost +
+        finalQuantity * executionPrice;
+      existingPosition.avgCost = totalCostBasis / totalQuantity;
+      existingPosition.quantity = totalQuantity;
+      existingPosition.currentPrice = executionPrice;
+      existingPosition.marketValue = totalQuantity * executionPrice;
+      existingPosition.unrealizedPnl =
+        totalQuantity * (executionPrice - existingPosition.avgCost);
+      existingPosition.unrealizedPnlPercent =
+        (executionPrice / existingPosition.avgCost - 1) * 100;
+      existingPosition.lastUpdate = timestamp;
+    } else {
+      this.positions.set(symbol, {
+        symbol,
+        quantity: finalQuantity,
+        avgCost: executionPrice,
+        currentPrice: executionPrice,
+        marketValue: finalQuantity * executionPrice,
+        unrealizedPnl: 0,
+        unrealizedPnlPercent: 0,
+        openDate: timestamp,
+        lastUpdate: timestamp,
+      });
+    }
+
+    // Record trade
+    const trade: Trade = {
+      id: generateTradeId(),
+      timestamp,
+      symbol,
+      side: 'buy',
+      quantity: finalQuantity,
+      price: executionPrice,
+      commission,
+      slippage: slippage * finalQuantity,
+      status: 'filled',
+    };
+
+    this.trades.push(trade);
+    return trade;
+  }
+
+  /** Execute a sell order */
+  sell(
+    symbol: string,
+    quantity: number,
+    price: number,
+    timestamp: number
+  ): Trade | null {
+    if (quantity <= 0) return null;
+
+    const position = this.positions.get(symbol);
+    if (!position || position.quantity <= 0) {
+      return null; // No position to sell
+    }
+
+    // Apply slippage
+    const slippage = this.calculateSlippage(price, 'sell');
+    const executionPrice = price + slippage;
+
+    // Can't sell more than we have
+    const finalQuantity = Math.min(
+      this.allowFractional ? quantity : Math.floor(quantity),
+      position.quantity
+    );
+
+    if (finalQuantity <= 0) return null;
+
+    // Calculate proceeds
+    const tradeValue = finalQuantity * executionPrice;
+    const commission = this.calculateCommission(finalQuantity, executionPrice);
+    const proceeds = tradeValue - commission;
+
+    // Calculate P&L for this trade
+    const costBasis = finalQuantity * position.avgCost;
+    const pnl = proceeds - costBasis + commission; // Add back commission for trade P&L
+    const pnlPercent = (executionPrice / position.avgCost - 1) * 100;
+
+    // Holding period
+    const holdingPeriodDays = Math.ceil(
+      (timestamp - position.openDate) / (24 * 60 * 60 * 1000)
+    );
+
+    // Add to cash
+    this.cash += proceeds;
+
+    // Update position
+    position.quantity -= finalQuantity;
+    position.lastUpdate = timestamp;
+
+    if (position.quantity <= 0.0001) {
+      // Close position (with small tolerance for floating point)
+      this.positions.delete(symbol);
+    } else {
+      position.marketValue = position.quantity * executionPrice;
+      position.unrealizedPnl =
+        position.quantity * (executionPrice - position.avgCost);
+      position.unrealizedPnlPercent =
+        (executionPrice / position.avgCost - 1) * 100;
+    }
+
+    // Record trade
+    const trade: Trade = {
+      id: generateTradeId(),
+      timestamp,
+      symbol,
+      side: 'sell',
+      quantity: finalQuantity,
+      price: executionPrice,
+      commission,
+      slippage: slippage * finalQuantity,
+      status: 'filled',
+      pnl,
+      pnlPercent,
+      holdingPeriodDays,
+    };
+
+    this.trades.push(trade);
+    return trade;
+  }
+
+  /** Close all positions */
+  closeAll(prices: Map<string, number>, timestamp: number): Trade[] {
+    const trades: Trade[] = [];
+
+    for (const [symbol, position] of this.positions) {
+      const price = prices.get(symbol);
+      if (price && position.quantity > 0) {
+        const trade = this.sell(symbol, position.quantity, price, timestamp);
+        if (trade) trades.push(trade);
+      }
+    }
+
+    return trades;
+  }
+
+  /** Update position prices (mark to market) */
+  updatePrices(prices: Map<string, number>, timestamp: number): void {
+    for (const [symbol, position] of this.positions) {
+      const price = prices.get(symbol);
+      if (price) {
+        position.currentPrice = price;
+        position.marketValue = position.quantity * price;
+        position.unrealizedPnl =
+          position.quantity * (price - position.avgCost);
+        position.unrealizedPnlPercent =
+          (price / position.avgCost - 1) * 100;
+        position.lastUpdate = timestamp;
+      }
+    }
+  }
+
+  /** Get total portfolio value */
+  getTotalValue(): number {
+    let invested = 0;
+    for (const position of this.positions.values()) {
+      invested += position.marketValue;
+    }
+    return this.cash + invested;
+  }
+
+  /** Get portfolio snapshot */
+  getSnapshot(timestamp: number, prevValue?: number): PortfolioSnapshot {
+    const totalValue = this.getTotalValue();
+    const dailyReturn = prevValue ? (totalValue / prevValue - 1) * 100 : 0;
+
+    return {
+      timestamp,
+      cash: this.cash,
+      positions: this.getPositions(),
+      totalValue,
+      dailyReturn,
+      cumulativeReturn: 0, // Will be calculated by engine
+    };
+  }
+
+  /** Reset portfolio to initial state */
+  reset(initialCapital: number): void {
+    this.cash = initialCapital;
+    this.positions.clear();
+    this.trades = [];
+    tradeIdCounter = 0;
+  }
+}

--- a/src/backtest/types.ts
+++ b/src/backtest/types.ts
@@ -1,0 +1,205 @@
+/**
+ * Backtesting Engine Types
+ * Commission-aware simulation with comprehensive metrics
+ */
+
+/** Trade side */
+export type TradeSide = 'buy' | 'sell';
+
+/** Trade status */
+export type TradeStatus = 'pending' | 'filled' | 'cancelled' | 'rejected';
+
+/** Position sizing method */
+export type PositionSizing = 'fixed' | 'percent' | 'kelly' | 'equal_weight';
+
+/** Rebalancing frequency */
+export type RebalanceFrequency = 'daily' | 'weekly' | 'monthly' | 'quarterly' | 'never';
+
+/** Individual trade record */
+export interface Trade {
+  id: string;
+  timestamp: number;
+  symbol: string;
+  side: TradeSide;
+  quantity: number;
+  price: number;
+  commission: number;
+  slippage: number;
+  status: TradeStatus;
+  pnl?: number;
+  pnlPercent?: number;
+  holdingPeriodDays?: number;
+}
+
+/** Open position */
+export interface Position {
+  symbol: string;
+  quantity: number;
+  avgCost: number;
+  currentPrice: number;
+  marketValue: number;
+  unrealizedPnl: number;
+  unrealizedPnlPercent: number;
+  openDate: number;
+  lastUpdate: number;
+}
+
+/** Portfolio snapshot at a point in time */
+export interface PortfolioSnapshot {
+  timestamp: number;
+  cash: number;
+  positions: Position[];
+  totalValue: number;
+  dailyReturn: number;
+  cumulativeReturn: number;
+}
+
+/** Commission configuration */
+export interface CommissionConfig {
+  /** Fixed fee per trade */
+  fixedFee: number;
+  /** Percentage of trade value */
+  percentFee: number;
+  /** Minimum commission */
+  minCommission: number;
+  /** Maximum commission */
+  maxCommission: number;
+}
+
+/** Slippage configuration */
+export interface SlippageConfig {
+  /** Fixed slippage in price units */
+  fixed: number;
+  /** Percentage slippage */
+  percent: number;
+  /** Enable random slippage variation */
+  randomize: boolean;
+}
+
+/** Backtest configuration */
+export interface BacktestConfig {
+  /** Initial capital */
+  initialCapital: number;
+  /** Commission settings */
+  commission: CommissionConfig;
+  /** Slippage settings */
+  slippage: SlippageConfig;
+  /** Position sizing method */
+  positionSizing: PositionSizing;
+  /** Fixed position size (for 'fixed' sizing) */
+  fixedPositionSize?: number;
+  /** Position size as % of portfolio (for 'percent' sizing) */
+  positionSizePercent?: number;
+  /** Maximum positions allowed */
+  maxPositions: number;
+  /** Maximum position size as % of portfolio */
+  maxPositionPercent: number;
+  /** Rebalancing frequency */
+  rebalanceFrequency: RebalanceFrequency;
+  /** Allow fractional shares */
+  allowFractional: boolean;
+  /** Risk-free rate for Sharpe calculation */
+  riskFreeRate: number;
+}
+
+/** Performance metrics */
+export interface PerformanceMetrics {
+  // Returns
+  totalReturn: number;
+  totalReturnPercent: number;
+  annualizedReturn: number;
+  cagr: number;
+
+  // Risk metrics
+  volatility: number;
+  sharpeRatio: number;
+  sortinoRatio: number;
+  calmarRatio: number;
+
+  // Drawdown
+  maxDrawdown: number;
+  maxDrawdownDuration: number; // days
+  avgDrawdown: number;
+
+  // Trade statistics
+  totalTrades: number;
+  winningTrades: number;
+  losingTrades: number;
+  winRate: number;
+  profitFactor: number;
+  avgWin: number;
+  avgLoss: number;
+  avgWinLossRatio: number;
+  largestWin: number;
+  largestLoss: number;
+  avgHoldingPeriod: number;
+
+  // Other
+  tradingDays: number;
+  startDate: number;
+  endDate: number;
+  finalValue: number;
+}
+
+/** Benchmark comparison */
+export interface BenchmarkComparison {
+  benchmarkReturn: number;
+  benchmarkVolatility: number;
+  benchmarkSharpe: number;
+  benchmarkMaxDrawdown: number;
+  alpha: number;
+  beta: number;
+  correlation: number;
+  informationRatio: number;
+  trackingError: number;
+  excessReturn: number;
+}
+
+/** Equity curve point */
+export interface EquityPoint {
+  date: number;
+  equity: number;
+  cash: number;
+  invested: number;
+  dailyReturn: number;
+  cumulativeReturn: number;
+  drawdown: number;
+  benchmark?: number;
+}
+
+/** Monthly returns table entry */
+export interface MonthlyReturn {
+  year: number;
+  month: number;
+  return: number;
+  benchmark?: number;
+}
+
+/** Complete backtest result */
+export interface BacktestResult {
+  config: BacktestConfig;
+  metrics: PerformanceMetrics;
+  benchmark?: BenchmarkComparison;
+  equityCurve: EquityPoint[];
+  monthlyReturns: MonthlyReturn[];
+  trades: Trade[];
+  finalPositions: Position[];
+}
+
+/** Price bar for backtest */
+export interface PriceBar {
+  timestamp: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+/** Backtest input data */
+export interface BacktestData {
+  symbols: string[];
+  prices: Map<string, PriceBar[]>;
+  startDate: number;
+  endDate: number;
+}

--- a/tests/backtest/engine.test.ts
+++ b/tests/backtest/engine.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Backtest Engine Tests
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { BacktestEngine, createBacktestEngine, DEFAULT_CONFIG } from '../../src/backtest/engine';
+import type { BacktestData, PriceBar } from '../../src/backtest/types';
+import type { Signal } from '../../src/strategies/types';
+
+describe('BacktestEngine', () => {
+  // Create sample price data
+  const createPriceData = (
+    symbol: string,
+    startPrice: number,
+    days: number,
+    trend: 'up' | 'down' | 'flat' = 'up'
+  ): PriceBar[] => {
+    const bars: PriceBar[] = [];
+    let price = startPrice;
+
+    for (let i = 0; i < days; i++) {
+      const change = trend === 'up' ? 1 : trend === 'down' ? -1 : 0;
+      price += change + (Math.random() - 0.5) * 2;
+      price = Math.max(price, 1);
+
+      bars.push({
+        timestamp: Date.now() - (days - i) * 86400000,
+        open: price - 0.5,
+        high: price + 1,
+        low: price - 1,
+        close: price,
+        volume: 1000000,
+      });
+    }
+
+    return bars;
+  };
+
+  const createBacktestData = (symbols: string[], days = 100): BacktestData => {
+    const prices = new Map<string, PriceBar[]>();
+
+    for (const symbol of symbols) {
+      prices.set(symbol, createPriceData(symbol, 100, days, 'up'));
+    }
+
+    const allBars = Array.from(prices.values()).flat();
+    const timestamps = allBars.map((b) => b.timestamp);
+
+    return {
+      symbols,
+      prices,
+      startDate: Math.min(...timestamps),
+      endDate: Math.max(...timestamps),
+    };
+  };
+
+  describe('initialization', () => {
+    test('should create with default config', () => {
+      const engine = new BacktestEngine();
+      const config = engine.getConfig();
+
+      expect(config.initialCapital).toBe(DEFAULT_CONFIG.initialCapital);
+      expect(config.maxPositions).toBe(DEFAULT_CONFIG.maxPositions);
+    });
+
+    test('should create with custom config', () => {
+      const engine = new BacktestEngine({
+        initialCapital: 50000,
+        maxPositions: 10,
+      });
+
+      const config = engine.getConfig();
+      expect(config.initialCapital).toBe(50000);
+      expect(config.maxPositions).toBe(10);
+    });
+
+    test('should create via factory function', () => {
+      const engine = createBacktestEngine({ initialCapital: 75000 });
+      expect(engine.getConfig().initialCapital).toBe(75000);
+    });
+  });
+
+  describe('run', () => {
+    test('should run backtest with signals', () => {
+      const engine = new BacktestEngine({
+        initialCapital: 100000,
+        positionSizing: 'equal_weight',
+        maxPositions: 5,
+      });
+
+      const data = createBacktestData(['AAPL', 'GOOGL'], 50);
+
+      // Simple signal generator: buy on first day
+      let firstDay = true;
+      const signalGenerator = (date: number): Signal[] => {
+        if (firstDay) {
+          firstDay = false;
+          return [
+            { symbol: 'AAPL', action: 'buy', confidence: 0.8, strength: 80, factors: [], timestamp: date },
+            { symbol: 'GOOGL', action: 'buy', confidence: 0.7, strength: 70, factors: [], timestamp: date },
+          ];
+        }
+        return [];
+      };
+
+      const result = engine.run(data, signalGenerator);
+
+      expect(result.equityCurve.length).toBeGreaterThan(0);
+      expect(result.trades.length).toBeGreaterThan(0);
+      expect(result.metrics).toBeDefined();
+      expect(result.metrics.tradingDays).toBeGreaterThan(0);
+    });
+
+    test('should track equity curve', () => {
+      const engine = new BacktestEngine({ initialCapital: 100000 });
+      const data = createBacktestData(['AAPL'], 30);
+
+      const result = engine.run(data, () => []);
+
+      expect(result.equityCurve.length).toBe(30);
+      expect(result.equityCurve[0].equity).toBe(100000);
+
+      // Check all equity points have required fields
+      for (const point of result.equityCurve) {
+        expect(point).toHaveProperty('date');
+        expect(point).toHaveProperty('equity');
+        expect(point).toHaveProperty('cash');
+        expect(point).toHaveProperty('dailyReturn');
+      }
+    });
+
+    test('should close all positions at end', () => {
+      const engine = new BacktestEngine();
+      const data = createBacktestData(['AAPL'], 20);
+
+      let bought = false;
+      const signalGenerator = (): Signal[] => {
+        if (!bought) {
+          bought = true;
+          return [{ symbol: 'AAPL', action: 'buy', confidence: 0.9, strength: 90, factors: [], timestamp: Date.now() }];
+        }
+        return [];
+      };
+
+      const result = engine.run(data, signalGenerator);
+
+      // Should have closing sells
+      const sells = result.trades.filter((t) => t.side === 'sell');
+      expect(sells.length).toBeGreaterThan(0);
+
+      // No final positions
+      expect(result.finalPositions).toHaveLength(0);
+    });
+
+    test('should respect max positions', () => {
+      const engine = new BacktestEngine({
+        maxPositions: 2,
+      });
+
+      const data = createBacktestData(['AAPL', 'GOOGL', 'MSFT', 'AMZN'], 30);
+
+      // Try to buy all 4 stocks
+      let firstDay = true;
+      const signalGenerator = (date: number): Signal[] => {
+        if (firstDay) {
+          firstDay = false;
+          return [
+            { symbol: 'AAPL', action: 'buy', confidence: 0.9, strength: 90, factors: [], timestamp: date },
+            { symbol: 'GOOGL', action: 'buy', confidence: 0.8, strength: 80, factors: [], timestamp: date },
+            { symbol: 'MSFT', action: 'buy', confidence: 0.7, strength: 70, factors: [], timestamp: date },
+            { symbol: 'AMZN', action: 'buy', confidence: 0.6, strength: 60, factors: [], timestamp: date },
+          ];
+        }
+        return [];
+      };
+
+      const result = engine.run(data, signalGenerator);
+
+      // Should only have 2 buy trades (max positions)
+      const buys = result.trades.filter((t) => t.side === 'buy');
+      expect(buys.length).toBe(2);
+
+      // Should be the highest confidence ones
+      expect(buys.some((t) => t.symbol === 'AAPL')).toBe(true);
+      expect(buys.some((t) => t.symbol === 'GOOGL')).toBe(true);
+    });
+
+    test('should calculate metrics', () => {
+      const engine = new BacktestEngine({ initialCapital: 100000 });
+      const data = createBacktestData(['AAPL'], 50);
+
+      let bought = false;
+      const signalGenerator = (date: number): Signal[] => {
+        if (!bought) {
+          bought = true;
+          return [{ symbol: 'AAPL', action: 'buy', confidence: 0.8, strength: 80, factors: [], timestamp: date }];
+        }
+        return [];
+      };
+
+      const result = engine.run(data, signalGenerator);
+
+      expect(result.metrics.totalTrades).toBeGreaterThan(0);
+      expect(result.metrics.tradingDays).toBe(50);
+      expect(result.metrics.startDate).toBeDefined();
+      expect(result.metrics.endDate).toBeDefined();
+    });
+
+    test('should handle empty signals', () => {
+      const engine = new BacktestEngine();
+      const data = createBacktestData(['AAPL'], 20);
+
+      const result = engine.run(data, () => []);
+
+      expect(result.trades).toHaveLength(0);
+      expect(result.equityCurve[result.equityCurve.length - 1].equity).toBe(100000);
+    });
+  });
+
+  describe('position sizing', () => {
+    test('should use equal weight sizing', () => {
+      const engine = new BacktestEngine({
+        initialCapital: 100000,
+        positionSizing: 'equal_weight',
+        maxPositions: 4,
+      });
+
+      const data = createBacktestData(['AAPL', 'GOOGL'], 20);
+
+      let firstDay = true;
+      const signalGenerator = (date: number): Signal[] => {
+        if (firstDay) {
+          firstDay = false;
+          return [
+            { symbol: 'AAPL', action: 'buy', confidence: 0.8, strength: 80, factors: [], timestamp: date },
+            { symbol: 'GOOGL', action: 'buy', confidence: 0.8, strength: 80, factors: [], timestamp: date },
+          ];
+        }
+        return [];
+      };
+
+      const result = engine.run(data, signalGenerator);
+      const buys = result.trades.filter((t) => t.side === 'buy');
+
+      // With equal weight, both positions should be similar size
+      if (buys.length === 2) {
+        const size1 = buys[0].quantity * buys[0].price;
+        const size2 = buys[1].quantity * buys[1].price;
+        const ratio = size1 / size2;
+        expect(ratio).toBeGreaterThan(0.5);
+        expect(ratio).toBeLessThan(2);
+      }
+    });
+  });
+
+  describe('rebalancing', () => {
+    test('should rebalance daily by default', () => {
+      const engine = new BacktestEngine({
+        rebalanceFrequency: 'daily',
+      });
+
+      const data = createBacktestData(['AAPL'], 10);
+
+      let callCount = 0;
+      const signalGenerator = (): Signal[] => {
+        callCount++;
+        return [];
+      };
+
+      engine.run(data, signalGenerator);
+
+      // Should be called every day
+      expect(callCount).toBe(10);
+    });
+
+    test('should respect never rebalance', () => {
+      const engine = new BacktestEngine({
+        rebalanceFrequency: 'never',
+      });
+
+      const data = createBacktestData(['AAPL'], 30);
+
+      let callCount = 0;
+      const signalGenerator = (): Signal[] => {
+        callCount++;
+        return [];
+      };
+
+      engine.run(data, signalGenerator);
+
+      // Should only be called on first day
+      expect(callCount).toBe(1);
+    });
+  });
+
+  describe('setConfig', () => {
+    test('should update configuration', () => {
+      const engine = new BacktestEngine({ initialCapital: 100000 });
+
+      engine.setConfig({ initialCapital: 50000, maxPositions: 5 });
+
+      const config = engine.getConfig();
+      expect(config.initialCapital).toBe(50000);
+      expect(config.maxPositions).toBe(5);
+    });
+  });
+});

--- a/tests/backtest/metrics.test.ts
+++ b/tests/backtest/metrics.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Metrics Tests
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+  calculateMetrics,
+  calculateBenchmarkComparison,
+  calculateMonthlyReturns,
+} from '../../src/backtest/metrics';
+import type { EquityPoint, Trade } from '../../src/backtest/types';
+
+describe('calculateMetrics', () => {
+  const createEquityCurve = (values: number[], startDate = Date.now()): EquityPoint[] => {
+    return values.map((equity, i) => ({
+      date: startDate + i * 86400000,
+      equity,
+      cash: equity * 0.1,
+      invested: equity * 0.9,
+      dailyReturn: i > 0 ? ((equity - values[i - 1]) / values[i - 1]) * 100 : 0,
+      cumulativeReturn: ((equity - values[0]) / values[0]) * 100,
+      drawdown: 0,
+    }));
+  };
+
+  test('should calculate total return', () => {
+    const curve = createEquityCurve([100000, 105000, 110000]);
+    const metrics = calculateMetrics(curve, [], 100000);
+
+    expect(metrics.totalReturn).toBe(10000);
+    expect(metrics.totalReturnPercent).toBe(10);
+  });
+
+  test('should calculate final value', () => {
+    const curve = createEquityCurve([100000, 120000, 115000]);
+    const metrics = calculateMetrics(curve, [], 100000);
+
+    expect(metrics.finalValue).toBe(115000);
+  });
+
+  test('should calculate max drawdown', () => {
+    // Peak at 120, trough at 90 = 25% drawdown
+    const curve = createEquityCurve([100000, 120000, 110000, 90000, 100000]);
+    const metrics = calculateMetrics(curve, [], 100000);
+
+    expect(metrics.maxDrawdown).toBeCloseTo(25, 0);
+  });
+
+  test('should calculate volatility', () => {
+    // Volatile sequence
+    const curve = createEquityCurve([100000, 110000, 95000, 115000, 100000]);
+    const metrics = calculateMetrics(curve, [], 100000);
+
+    expect(metrics.volatility).toBeGreaterThan(0);
+  });
+
+  test('should calculate trade statistics', () => {
+    const trades: Trade[] = [
+      { id: '1', timestamp: Date.now(), symbol: 'AAPL', side: 'buy', quantity: 100, price: 150, commission: 0, slippage: 0, status: 'filled' },
+      { id: '2', timestamp: Date.now(), symbol: 'AAPL', side: 'sell', quantity: 100, price: 160, commission: 0, slippage: 0, status: 'filled', pnl: 1000, pnlPercent: 6.67, holdingPeriodDays: 5 },
+      { id: '3', timestamp: Date.now(), symbol: 'GOOGL', side: 'buy', quantity: 50, price: 100, commission: 0, slippage: 0, status: 'filled' },
+      { id: '4', timestamp: Date.now(), symbol: 'GOOGL', side: 'sell', quantity: 50, price: 90, commission: 0, slippage: 0, status: 'filled', pnl: -500, pnlPercent: -10, holdingPeriodDays: 3 },
+    ];
+
+    const curve = createEquityCurve([100000, 100500]);
+    const metrics = calculateMetrics(curve, trades, 100000);
+
+    expect(metrics.totalTrades).toBe(4);
+    expect(metrics.winningTrades).toBe(1);
+    expect(metrics.losingTrades).toBe(1);
+    expect(metrics.winRate).toBe(50);
+    expect(metrics.profitFactor).toBe(2); // 1000/500
+    expect(metrics.avgWin).toBe(1000);
+    expect(metrics.avgLoss).toBe(500);
+    expect(metrics.largestWin).toBe(1000);
+    expect(metrics.largestLoss).toBe(500);
+  });
+
+  test('should handle empty equity curve', () => {
+    const metrics = calculateMetrics([], [], 100000);
+
+    expect(metrics.totalReturn).toBe(0);
+    expect(metrics.sharpeRatio).toBe(0);
+    expect(metrics.maxDrawdown).toBe(0);
+  });
+});
+
+describe('calculateBenchmarkComparison', () => {
+  test('should calculate excess return', () => {
+    const equityCurve: EquityPoint[] = [
+      { date: 1, equity: 100000, cash: 10000, invested: 90000, dailyReturn: 0, cumulativeReturn: 0, drawdown: 0 },
+      { date: 2, equity: 120000, cash: 12000, invested: 108000, dailyReturn: 20, cumulativeReturn: 20, drawdown: 0 },
+    ];
+    const benchmarkPrices = [100, 110];
+
+    const comparison = calculateBenchmarkComparison(equityCurve, benchmarkPrices);
+
+    expect(comparison.benchmarkReturn).toBeCloseTo(10, 5); // 10% benchmark return
+    expect(comparison.excessReturn).toBeCloseTo(10, 5); // Strategy 20% - Benchmark 10%
+  });
+
+  test('should calculate correlation', () => {
+    const equityCurve: EquityPoint[] = [
+      { date: 1, equity: 100, cash: 10, invested: 90, dailyReturn: 0, cumulativeReturn: 0, drawdown: 0 },
+      { date: 2, equity: 110, cash: 11, invested: 99, dailyReturn: 10, cumulativeReturn: 10, drawdown: 0 },
+      { date: 3, equity: 120, cash: 12, invested: 108, dailyReturn: 9.1, cumulativeReturn: 20, drawdown: 0 },
+    ];
+    const benchmarkPrices = [100, 110, 120];
+
+    const comparison = calculateBenchmarkComparison(equityCurve, benchmarkPrices);
+
+    // Perfect correlation when moving together
+    expect(comparison.correlation).toBeGreaterThan(0.9);
+  });
+
+  test('should handle empty data', () => {
+    const comparison = calculateBenchmarkComparison([], []);
+
+    expect(comparison.alpha).toBe(0);
+    expect(comparison.beta).toBe(1);
+    expect(comparison.correlation).toBe(0);
+  });
+});
+
+describe('calculateMonthlyReturns', () => {
+  test('should calculate monthly returns', () => {
+    const startDate = new Date('2024-01-15').getTime();
+    const midMonth = new Date('2024-01-25').getTime();
+    const nextMonth = new Date('2024-02-15').getTime();
+
+    const equityCurve: EquityPoint[] = [
+      { date: startDate, equity: 100000, cash: 10000, invested: 90000, dailyReturn: 0, cumulativeReturn: 0, drawdown: 0 },
+      { date: midMonth, equity: 105000, cash: 10500, invested: 94500, dailyReturn: 0.5, cumulativeReturn: 5, drawdown: 0 },
+      { date: nextMonth, equity: 110000, cash: 11000, invested: 99000, dailyReturn: 0.5, cumulativeReturn: 10, drawdown: 0 },
+    ];
+
+    const monthlyReturns = calculateMonthlyReturns(equityCurve);
+
+    expect(monthlyReturns.length).toBeGreaterThan(0);
+    expect(monthlyReturns[0]).toHaveProperty('year');
+    expect(monthlyReturns[0]).toHaveProperty('month');
+    expect(monthlyReturns[0]).toHaveProperty('return');
+  });
+
+  test('should handle empty curve', () => {
+    const monthlyReturns = calculateMonthlyReturns([]);
+    expect(monthlyReturns).toHaveLength(0);
+  });
+});

--- a/tests/backtest/portfolio.test.ts
+++ b/tests/backtest/portfolio.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Portfolio Tests
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { Portfolio, DEFAULT_COMMISSION, DEFAULT_SLIPPAGE } from '../../src/backtest/portfolio';
+
+describe('Portfolio', () => {
+  let portfolio: Portfolio;
+  const initialCapital = 100000;
+
+  beforeEach(() => {
+    portfolio = new Portfolio(initialCapital);
+  });
+
+  describe('initialization', () => {
+    test('should initialize with correct cash', () => {
+      expect(portfolio.getCash()).toBe(initialCapital);
+    });
+
+    test('should start with no positions', () => {
+      expect(portfolio.getPositions()).toHaveLength(0);
+    });
+
+    test('should start with no trades', () => {
+      expect(portfolio.getTrades()).toHaveLength(0);
+    });
+  });
+
+  describe('buy', () => {
+    test('should execute buy order', () => {
+      const trade = portfolio.buy('AAPL', 100, 150, Date.now());
+
+      expect(trade).not.toBeNull();
+      expect(trade!.side).toBe('buy');
+      expect(trade!.symbol).toBe('AAPL');
+      expect(trade!.quantity).toBe(100);
+      expect(trade!.status).toBe('filled');
+    });
+
+    test('should deduct cash for purchase', () => {
+      portfolio.buy('AAPL', 100, 150, Date.now());
+
+      // Cash should be reduced by cost + commission + slippage
+      expect(portfolio.getCash()).toBeLessThan(initialCapital);
+      expect(portfolio.getCash()).toBeLessThan(initialCapital - 15000); // At least cost
+    });
+
+    test('should create position', () => {
+      portfolio.buy('AAPL', 100, 150, Date.now());
+
+      const position = portfolio.getPosition('AAPL');
+      expect(position).toBeDefined();
+      expect(position!.quantity).toBe(100);
+      expect(position!.symbol).toBe('AAPL');
+    });
+
+    test('should average cost on second buy', () => {
+      portfolio.buy('AAPL', 100, 100, Date.now());
+      portfolio.buy('AAPL', 100, 200, Date.now());
+
+      const position = portfolio.getPosition('AAPL');
+      expect(position!.quantity).toBe(200);
+      // Average cost should be between 100 and 200 (with slippage)
+      expect(position!.avgCost).toBeGreaterThan(100);
+      expect(position!.avgCost).toBeLessThan(210);
+    });
+
+    test('should reject buy with insufficient funds', () => {
+      const trade = portfolio.buy('AAPL', 10000, 150, Date.now()); // $1.5M, too expensive
+
+      expect(trade).toBeNull();
+      expect(portfolio.getCash()).toBe(initialCapital);
+    });
+
+    test('should reject zero quantity', () => {
+      const trade = portfolio.buy('AAPL', 0, 150, Date.now());
+      expect(trade).toBeNull();
+    });
+  });
+
+  describe('sell', () => {
+    beforeEach(() => {
+      portfolio.buy('AAPL', 100, 150, Date.now() - 86400000); // Buy yesterday
+    });
+
+    test('should execute sell order', () => {
+      const trade = portfolio.sell('AAPL', 50, 160, Date.now());
+
+      expect(trade).not.toBeNull();
+      expect(trade!.side).toBe('sell');
+      expect(trade!.quantity).toBe(50);
+      expect(trade!.status).toBe('filled');
+    });
+
+    test('should add proceeds to cash', () => {
+      const cashAfterBuy = portfolio.getCash();
+      portfolio.sell('AAPL', 50, 160, Date.now());
+
+      expect(portfolio.getCash()).toBeGreaterThan(cashAfterBuy);
+    });
+
+    test('should calculate P&L', () => {
+      const trade = portfolio.sell('AAPL', 50, 180, Date.now());
+
+      expect(trade!.pnl).toBeDefined();
+      expect(trade!.pnl!).toBeGreaterThan(0); // Sold higher than bought
+    });
+
+    test('should calculate holding period', () => {
+      const trade = portfolio.sell('AAPL', 50, 160, Date.now());
+
+      expect(trade!.holdingPeriodDays).toBeDefined();
+      expect(trade!.holdingPeriodDays!).toBeGreaterThanOrEqual(1);
+    });
+
+    test('should reduce position', () => {
+      portfolio.sell('AAPL', 50, 160, Date.now());
+
+      const position = portfolio.getPosition('AAPL');
+      expect(position!.quantity).toBe(50);
+    });
+
+    test('should close position on full sell', () => {
+      portfolio.sell('AAPL', 100, 160, Date.now());
+
+      const position = portfolio.getPosition('AAPL');
+      expect(position).toBeUndefined();
+    });
+
+    test('should not sell more than owned', () => {
+      const trade = portfolio.sell('AAPL', 200, 160, Date.now());
+
+      expect(trade!.quantity).toBe(100); // Only sold what we had
+    });
+
+    test('should reject sell without position', () => {
+      const trade = portfolio.sell('GOOGL', 50, 100, Date.now());
+      expect(trade).toBeNull();
+    });
+  });
+
+  describe('commission calculation', () => {
+    test('should apply percentage commission', () => {
+      const commission = portfolio.calculateCommission(100, 150);
+
+      // Default is 0.1% = 15 for $15,000 trade
+      expect(commission).toBeCloseTo(15, 0);
+    });
+
+    test('should apply minimum commission', () => {
+      const customPortfolio = new Portfolio(initialCapital, {
+        ...DEFAULT_COMMISSION,
+        minCommission: 5,
+      });
+
+      const commission = customPortfolio.calculateCommission(1, 10);
+      expect(commission).toBeGreaterThanOrEqual(5);
+    });
+
+    test('should apply maximum commission', () => {
+      const customPortfolio = new Portfolio(initialCapital, {
+        ...DEFAULT_COMMISSION,
+        maxCommission: 10,
+      });
+
+      const commission = customPortfolio.calculateCommission(1000, 150);
+      expect(commission).toBe(10);
+    });
+  });
+
+  describe('closeAll', () => {
+    test('should close all positions', () => {
+      portfolio.buy('AAPL', 50, 150, Date.now());
+      portfolio.buy('GOOGL', 30, 100, Date.now());
+
+      const prices = new Map([
+        ['AAPL', 160],
+        ['GOOGL', 110],
+      ]);
+
+      const trades = portfolio.closeAll(prices, Date.now());
+
+      expect(trades).toHaveLength(2);
+      expect(portfolio.getPositions()).toHaveLength(0);
+    });
+  });
+
+  describe('updatePrices', () => {
+    test('should update unrealized P&L', () => {
+      portfolio.buy('AAPL', 100, 150, Date.now());
+
+      const prices = new Map([['AAPL', 180]]);
+      portfolio.updatePrices(prices, Date.now());
+
+      const position = portfolio.getPosition('AAPL');
+      expect(position!.currentPrice).toBe(180);
+      expect(position!.unrealizedPnl).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getTotalValue', () => {
+    test('should return cash when no positions', () => {
+      expect(portfolio.getTotalValue()).toBe(initialCapital);
+    });
+
+    test('should include position value', () => {
+      portfolio.buy('AAPL', 100, 150, Date.now());
+
+      const value = portfolio.getTotalValue();
+      // Should be close to initial (some lost to commission/slippage)
+      expect(value).toBeLessThan(initialCapital);
+      expect(value).toBeGreaterThan(initialCapital * 0.99);
+    });
+  });
+
+  describe('reset', () => {
+    test('should reset to initial state', () => {
+      portfolio.buy('AAPL', 100, 150, Date.now());
+      portfolio.reset(50000);
+
+      expect(portfolio.getCash()).toBe(50000);
+      expect(portfolio.getPositions()).toHaveLength(0);
+      expect(portfolio.getTrades()).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the core backtesting module for Issue #4:

- **Portfolio Management**: Position tracking with average cost basis, P&L calculation, unrealized gains tracking
- **Commission/Slippage Modeling**: Percentage-based, fixed, or hybrid commission with min/max caps; slippage simulation
- **Performance Metrics**: 20+ metrics including Sharpe ratio, Sortino ratio, Calmar ratio, max drawdown, win rate, profit factor
- **Benchmark Comparison**: Alpha, beta, correlation, tracking error, information ratio
- **Position Sizing**: Equal weight, percentage, fixed amount, Kelly criterion
- **Rebalance Frequency**: Daily, weekly, monthly, quarterly, or never
- **Monthly Returns**: Breakdown by year/month for performance analysis

## Test plan

- [x] Portfolio buy/sell operations (17 tests)
- [x] Commission and slippage calculations (4 tests)
- [x] Metrics calculations (7 tests)
- [x] Benchmark comparison (3 tests)
- [x] Engine backtest execution (10 tests)
- [x] Position sizing strategies (2 tests)
- [x] Rebalance frequency handling (2 tests)
- [x] Edge cases (empty data, no trades) (4 tests)

**Total: 49 tests, all passing**

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)