### PR TITLE
fix(backtest): prevent NaN/Infinity in metrics and handle numeric config (#27)

### DIFF
--- a/tests/backtest/metrics.test.ts
+++ b/tests/backtest/metrics.test.ts
@@ -56,10 +56,56 @@ describe('calculateMetrics', () => {
 
   test('should calculate trade statistics', () => {
     const trades: Trade[] = [
-      { id: '1', timestamp: Date.now(), symbol: 'AAPL', side: 'buy', quantity: 100, price: 150, commission: 0, slippage: 0, status: 'filled' },
-      { id: '2', timestamp: Date.now(), symbol: 'AAPL', side: 'sell', quantity: 100, price: 160, commission: 0, slippage: 0, status: 'filled', pnl: 1000, pnlPercent: 6.67, holdingPeriodDays: 5 },
-      { id: '3', timestamp: Date.now(), symbol: 'GOOGL', side: 'buy', quantity: 50, price: 100, commission: 0, slippage: 0, status: 'filled' },
-      { id: '4', timestamp: Date.now(), symbol: 'GOOGL', side: 'sell', quantity: 50, price: 90, commission: 0, slippage: 0, status: 'filled', pnl: -500, pnlPercent: -10, holdingPeriodDays: 3 },
+      {
+        id: '1',
+        timestamp: Date.now(),
+        symbol: 'AAPL',
+        side: 'buy',
+        quantity: 100,
+        price: 150,
+        commission: 0,
+        slippage: 0,
+        status: 'filled',
+      },
+      {
+        id: '2',
+        timestamp: Date.now(),
+        symbol: 'AAPL',
+        side: 'sell',
+        quantity: 100,
+        price: 160,
+        commission: 0,
+        slippage: 0,
+        status: 'filled',
+        pnl: 1000,
+        pnlPercent: 6.67,
+        holdingPeriodDays: 5,
+      },
+      {
+        id: '3',
+        timestamp: Date.now(),
+        symbol: 'GOOGL',
+        side: 'buy',
+        quantity: 50,
+        price: 100,
+        commission: 0,
+        slippage: 0,
+        status: 'filled',
+      },
+      {
+        id: '4',
+        timestamp: Date.now(),
+        symbol: 'GOOGL',
+        side: 'sell',
+        quantity: 50,
+        price: 90,
+        commission: 0,
+        slippage: 0,
+        status: 'filled',
+        pnl: -500,
+        pnlPercent: -10,
+        holdingPeriodDays: 3,
+      },
     ];
 
     const curve = createEquityCurve([100000, 100500]);
@@ -88,8 +134,24 @@ describe('calculateMetrics', () => {
 describe('calculateBenchmarkComparison', () => {
   test('should calculate excess return', () => {
     const equityCurve: EquityPoint[] = [
-      { date: 1, equity: 100000, cash: 10000, invested: 90000, dailyReturn: 0, cumulativeReturn: 0, drawdown: 0 },
-      { date: 2, equity: 120000, cash: 12000, invested: 108000, dailyReturn: 20, cumulativeReturn: 20, drawdown: 0 },
+      {
+        date: 1,
+        equity: 100000,
+        cash: 10000,
+        invested: 90000,
+        dailyReturn: 0,
+        cumulativeReturn: 0,
+        drawdown: 0,
+      },
+      {
+        date: 2,
+        equity: 120000,
+        cash: 12000,
+        invested: 108000,
+        dailyReturn: 20,
+        cumulativeReturn: 20,
+        drawdown: 0,
+      },
     ];
     const benchmarkPrices = [100, 110];
 
@@ -101,9 +163,33 @@ describe('calculateBenchmarkComparison', () => {
 
   test('should calculate correlation', () => {
     const equityCurve: EquityPoint[] = [
-      { date: 1, equity: 100, cash: 10, invested: 90, dailyReturn: 0, cumulativeReturn: 0, drawdown: 0 },
-      { date: 2, equity: 110, cash: 11, invested: 99, dailyReturn: 10, cumulativeReturn: 10, drawdown: 0 },
-      { date: 3, equity: 120, cash: 12, invested: 108, dailyReturn: 9.1, cumulativeReturn: 20, drawdown: 0 },
+      {
+        date: 1,
+        equity: 100,
+        cash: 10,
+        invested: 90,
+        dailyReturn: 0,
+        cumulativeReturn: 0,
+        drawdown: 0,
+      },
+      {
+        date: 2,
+        equity: 110,
+        cash: 11,
+        invested: 99,
+        dailyReturn: 10,
+        cumulativeReturn: 10,
+        drawdown: 0,
+      },
+      {
+        date: 3,
+        equity: 120,
+        cash: 12,
+        invested: 108,
+        dailyReturn: 9.1,
+        cumulativeReturn: 20,
+        drawdown: 0,
+      },
     ];
     const benchmarkPrices = [100, 110, 120];
 
@@ -129,9 +215,33 @@ describe('calculateMonthlyReturns', () => {
     const nextMonth = new Date('2024-02-15').getTime();
 
     const equityCurve: EquityPoint[] = [
-      { date: startDate, equity: 100000, cash: 10000, invested: 90000, dailyReturn: 0, cumulativeReturn: 0, drawdown: 0 },
-      { date: midMonth, equity: 105000, cash: 10500, invested: 94500, dailyReturn: 0.5, cumulativeReturn: 5, drawdown: 0 },
-      { date: nextMonth, equity: 110000, cash: 11000, invested: 99000, dailyReturn: 0.5, cumulativeReturn: 10, drawdown: 0 },
+      {
+        date: startDate,
+        equity: 100000,
+        cash: 10000,
+        invested: 90000,
+        dailyReturn: 0,
+        cumulativeReturn: 0,
+        drawdown: 0,
+      },
+      {
+        date: midMonth,
+        equity: 105000,
+        cash: 10500,
+        invested: 94500,
+        dailyReturn: 0.5,
+        cumulativeReturn: 5,
+        drawdown: 0,
+      },
+      {
+        date: nextMonth,
+        equity: 110000,
+        cash: 11000,
+        invested: 99000,
+        dailyReturn: 0.5,
+        cumulativeReturn: 10,
+        drawdown: 0,
+      },
     ];
 
     const monthlyReturns = calculateMonthlyReturns(equityCurve);
@@ -145,5 +255,96 @@ describe('calculateMonthlyReturns', () => {
   test('should handle empty curve', () => {
     const monthlyReturns = calculateMonthlyReturns([]);
     expect(monthlyReturns).toHaveLength(0);
+  });
+});
+
+describe('Metrics Edge Cases (Issue #27 regression)', () => {
+  const createEquityCurve = (values: number[], startDate = Date.now()): EquityPoint[] => {
+    return values.map((equity, i) => ({
+      date: startDate + i * 86400000,
+      equity,
+      cash: equity * 0.1,
+      invested: equity * 0.9,
+      dailyReturn: i > 0 ? ((equity - values[i - 1]) / values[i - 1]) * 100 : 0,
+      cumulativeReturn: ((equity - values[0]) / values[0]) * 100,
+      drawdown: 0,
+    }));
+  };
+
+  test('should not return NaN for any metric with valid data', () => {
+    const curve = createEquityCurve([100000, 105000, 103000, 107000]);
+    const metrics = calculateMetrics(curve, [], 100000);
+
+    expect(isNaN(metrics.totalReturn)).toBe(false);
+    expect(isNaN(metrics.totalReturnPercent)).toBe(false);
+    expect(isNaN(metrics.sharpeRatio)).toBe(false);
+    expect(isNaN(metrics.sortinoRatio)).toBe(false);
+    expect(isNaN(metrics.volatility)).toBe(false);
+    expect(isNaN(metrics.maxDrawdown)).toBe(false);
+    expect(isNaN(metrics.finalValue)).toBe(false);
+  });
+
+  test('should return 0 sharpe ratio for flat equity curve (zero volatility)', () => {
+    // All same values - zero volatility
+    const curve = createEquityCurve([100000, 100000, 100000, 100000]);
+    const metrics = calculateMetrics(curve, [], 100000);
+
+    expect(metrics.sharpeRatio).toBe(0);
+    expect(isNaN(metrics.sharpeRatio)).toBe(false);
+    expect(isFinite(metrics.sharpeRatio)).toBe(true);
+  });
+
+  test('should not overflow sharpe ratio (should be clamped)', () => {
+    const curve = createEquityCurve([100000, 100001, 100000, 100001]);
+    const metrics = calculateMetrics(curve, [], 100000);
+
+    // Sharpe should be clamped between -100 and 100
+    expect(metrics.sharpeRatio).toBeGreaterThanOrEqual(-100);
+    expect(metrics.sharpeRatio).toBeLessThanOrEqual(100);
+    expect(isFinite(metrics.sharpeRatio)).toBe(true);
+  });
+
+  test('should handle empty equity curve', () => {
+    const metrics = calculateMetrics([], [], 100000);
+
+    expect(metrics.sharpeRatio).toBe(0);
+    expect(metrics.totalReturn).toBe(0);
+    expect(metrics.finalValue).toBe(0);
+  });
+
+  test('should handle zero initial capital', () => {
+    const curve = createEquityCurve([0, 100, 200]);
+    const metrics = calculateMetrics(curve, [], 0);
+
+    expect(metrics.totalReturnPercent).toBe(0);
+    expect(isNaN(metrics.totalReturnPercent)).toBe(false);
+  });
+
+  test('should handle single data point', () => {
+    const curve = createEquityCurve([100000]);
+    const metrics = calculateMetrics(curve, [], 100000);
+
+    expect(metrics.sharpeRatio).toBe(0);
+    expect(metrics.volatility).toBe(0);
+    expect(isNaN(metrics.sharpeRatio)).toBe(false);
+  });
+
+  test('should not return Infinity for sortino ratio', () => {
+    // All positive returns (no downside)
+    const curve = createEquityCurve([100000, 101000, 102000, 103000]);
+    const metrics = calculateMetrics(curve, [], 100000);
+
+    expect(isFinite(metrics.sortinoRatio)).toBe(true);
+    expect(metrics.sortinoRatio).toBeLessThanOrEqual(100);
+  });
+
+  test('should handle very small price changes without overflow', () => {
+    // Tiny price changes that could cause near-zero volatility
+    const curve = createEquityCurve([100000, 100000.01, 100000.02, 100000.01, 100000.03]);
+    const metrics = calculateMetrics(curve, [], 100000);
+
+    expect(isFinite(metrics.sharpeRatio)).toBe(true);
+    expect(isFinite(metrics.sortinoRatio)).toBe(true);
+    expect(Math.abs(metrics.sharpeRatio)).toBeLessThanOrEqual(100);
   });
 });


### PR DESCRIPTION
## Summary
- Add `isValidNumber()` and `safeDivide()` helper functions for safe arithmetic in metrics calculations
- Clamp Sharpe and Sortino ratios to [-100, 100] to prevent overflow when volatility approaches zero
- Handle edge cases: zero volatility, empty equity curves, zero initial capital, single data points
- Add `normalizeCommissionConfig()` and `normalizeSlippageConfig()` to accept both numeric and object configurations
- Add 8 regression tests for Issue #27 edge cases
- Fix ESLint errors in switch case blocks (pre-existing)

## Root Cause Analysis
**Issue #27 (Sharpe ratio overflow)**: When volatility is zero or near-zero, dividing by it produces Infinity or extremely large numbers (e.g., -13205587641259414).

**Additional bug found**: The BacktestEngine was passing numeric commission/slippage values directly to Portfolio, which expects config objects. This caused `(0.001).fixedFee` to return `undefined`, resulting in NaN propagation through all calculations.

## Test plan
- [x] All 412 existing tests pass
- [x] 8 new regression tests for edge cases pass
- [x] Live integration test with Binance data passes (26 trades executed, valid metrics)
- [x] Verify Sharpe ratio is clamped: returns -2.591 instead of -13205587641259414

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)